### PR TITLE
Fix issues caused by native HTML5 validation

### DIFF
--- a/views/content/form.html
+++ b/views/content/form.html
@@ -1,4 +1,4 @@
-<form action="{{action}}" method="post" enctype="multipart/form-data">
+<form action="{{action}}" method="post" enctype="multipart/form-data" novalidate>
 
   {{form.html | safe}}
 

--- a/views/login.html
+++ b/views/login.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block main %}
-<form action="/login" method="post">
+<form action="/login" method="post" novalidate>
   {{message}}
   <div><label for="email">Email:<input type="text" id="email" name="email"/></label></div>
   <div><label for="password">Password:<input type="password" id="password" name="password"/></label></div>

--- a/views/users/_form.html
+++ b/views/users/_form.html
@@ -1,4 +1,4 @@
-<form action="{{action}}" method="post" enctype="multipart/form-data">
+<form action="{{action}}" method="post" enctype="multipart/form-data" novalidate>
 
   {{form.html|safe}}
 

--- a/views/users/delete.html
+++ b/views/users/delete.html
@@ -14,7 +14,7 @@
 <p class="form--alert" role="alert" for="delete">{{ message }}</p>
 {% endif %}
 
-<form action="{{action}}" method="post" enctype="multipart/form-data">
+<form action="{{action}}" method="post" enctype="multipart/form-data" novalidate>
 
   <p>Delete {{email}}?</p>
   <p>This cannot be undone!</p>


### PR DESCRIPTION
Native HTML5 validation is a bit of a pain. We are handling it ourself

**Changelog**

```markdown
**Changed**

* Disabled native HTML5 form validation for all current forms.
```

---
`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`
