### PR TITLE
Remove Changelog from PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,6 @@
 {{short description}}
 
-**Changelog**
-
-```markdown
-**New**
-
-* {{new thing}}
-* {{other new thing}}
-
-**Changed**
-
-* {{change thing}}
-* {{other change thing}}
-
-**Removed**
-
-* {{removed thing}}
-* {{other removed thing}}
-```
-
 ---
-Resolves: #
+Resolves #
 
 `DCO 1.1 Signed-off-by: {{full name}} <{{email address}}>`


### PR DESCRIPTION
Updates PR template to remove Changelog from said template. No longer needed as changelog is automatically generated. Also removes colon between resolves and issue number so it automatically closes now

---

`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`