### PR TITLE
Add Year and Company to Copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 IBM
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copyright year and company were missing from license

---

`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`

