### PR TITLE
Move Modular Scale to full dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "serve-favicon": "^2.3.0",
     "underscore.string": "^3.3.4",
     "uuid": "^2.0.2",
+    "modularscale-sass": "^2.1.1",
     "validator": "^5.4.0"
   },
   "devDependencies": {
@@ -84,7 +85,6 @@
     "jsdom": "^9.2.0",
     "lorem-ipsum": "^1.0.3",
     "mock-express-response": "^0.1.2",
-    "modularscale-sass": "^2.1.1",
     "nyc": "^6.6.1",
     "punchcard-commit-msg": "^1.0.0",
     "punchcard-runner": "^2.1.2",


### PR DESCRIPTION
Modular Scale is a full dependency, not a dev dependency

---

`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`

