### PR TITLE
fixes complatibility with content-types

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -21,6 +21,9 @@ module.exports = {
       revisions: 'revisions',
       save: 'save',
     },
+    plugins: {
+      directory: [],
+    },
     directory: path.join(__dirname, '../content-types'),
     messages: {
       content: {


### PR DESCRIPTION
Adds blank array to the config to make it search for the input plugins


`DCO 1.1 Signed-off-by: {{Ayush Gupta}} <{{ayush2k@gmail.com}}>`

