### PR TITLE
Fix typo in login error message

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -74,7 +74,7 @@ module.exports = {
   authentication: {
     messages: {
       login: {
-        error: 'Email and/or passowrd incorrect',
+        error: 'Email and/or password incorrect',
       },
     },
     login: {


### PR DESCRIPTION
A typo in the word `password` exists at path/file `config/default.js`.

---
Resolves #284

`DCO 1.1 Signed-off-by: Roy Vanegas <roy@thecodeeducators.com>`

