### PR TITLE
errors not caught with custom err handler

### DIFF
--- a/config/default-test.js
+++ b/config/default-test.js
@@ -15,7 +15,7 @@ if (process.env.CI === 'true') {
       database: 'travis_ci_test',
     },
     debug: false,
-    acquireConnectionTimeout: 1000,
+    acquireConnectionTimeout: 2000,
   };
 }
 

--- a/config/default.js
+++ b/config/default.js
@@ -52,7 +52,7 @@ module.exports = {
       database: 'punchcard',
     },
     debug: false,
-    acquireConnectionTimeout: 1000,
+    acquireConnectionTimeout: 2000,
   },
   site: {
     name: 'Punchcard CMS',

--- a/lib/errors/routes.js
+++ b/lib/errors/routes.js
@@ -66,7 +66,7 @@ const errors = (err, req, res, next, app) => {
 
     res.status(error.status || 500);
 
-    if (error.status === '404') {
+    if (error.status === 404) {
       res.render('404', error);
     }
     else {

--- a/lib/errors/routes.js
+++ b/lib/errors/routes.js
@@ -15,7 +15,7 @@ const _ = require('lodash');
  *
  * @returns {promise} promise containing the route
  */
-const notFound = (req, res) => {
+const missing = (req, res) => {
   return new Promise((resolve) => {
     const message = _.get(req.session, '404.message', `Not Found: ${req.url}`);
     const safe = _.get(req.session, '404.safe');
@@ -65,12 +65,19 @@ const errors = (err, req, res, next, app) => {
     }
 
     res.status(error.status || 500);
-    res.render('error', error);
+
+    if (error.status === '404') {
+      res.render('404', error);
+    }
+    else {
+      res.render('error', error);
+    }
+
     resolve(true);
   });
 };
 
 module.exports = {
-  notFound,
+  missing,
   errors,
 };

--- a/lib/errors/routes.js
+++ b/lib/errors/routes.js
@@ -1,0 +1,76 @@
+/**
+ *  @fileoverview Error routes
+ *
+ *  @author  Scott Nath
+ *
+ */
+'use strict';
+
+const _ = require('lodash');
+
+/**
+ * Route for a 404 error
+ * @param {object} req - HTTP Request
+ * @param {object} res - HTTP Response
+ *
+ * @returns {promise} promise containing the route
+ */
+const notFound = (req, res) => {
+  return new Promise((resolve) => {
+    const message = _.get(req.session, '404.message', `Not Found: ${req.url}`);
+    const safe = _.get(req.session, '404.safe');
+
+    _.unset(req.session, '404');
+
+    res.status(404);
+    res.render('404', {
+      message,
+      safe,
+    });
+    resolve(true);
+  });
+};
+
+/**
+ * Route for errors
+ *
+ * @param {string|object} err - error object or error message string
+ * @param {object} req - HTTP Request
+ * @param {object} res - HTTP Response
+ * @param {object} next - Express callback
+ * @param {object} app Express application
+ *
+ * @returns {promise} promise containing the route
+ */
+const errors = (err, req, res, next, app) => {
+  return new Promise((resolve) => {
+    let error = {
+      message: 'route error',
+      status: '',
+      safe: '/',
+    };
+
+    if (typeof err === 'object') {
+      error = _.cloneDeep(err);
+    }
+    else if (typeof err === 'string' && err !== '') {
+      error.message = err;
+    }
+
+    error.error = {};
+
+    // If in development, will print stacktrace
+    if (app.get('env') === 'development') {
+      error.error = err;
+    }
+
+    res.status(error.status || 500);
+    res.render('error', error);
+    resolve(true);
+  });
+};
+
+module.exports = {
+  notFound,
+  errors,
+};

--- a/lib/routes/content.js
+++ b/lib/routes/content.js
@@ -150,12 +150,13 @@ const routes = application => {
         .where('id', req.params.id)
         .orderBy('revision', 'DESC').then(rws => {
           if (rws.length < 1) {
-            _.set(req.session, '404', {
+            const err = {
               message: config.content.messages.missing.id.replace('%type', req.params.type).replace('%id', req.params.id),
               safe: `/${config.content.base}/${req.params.type}`,
-            });
+              status: 404,
+            };
 
-            return next();
+            return next(err);
           }
 
           // add itentifier to each row
@@ -204,12 +205,13 @@ const routes = application => {
         .where('revision', req.params.revision)
         .orderBy('revision', 'DESC').then(rws => {
           if (rws.length < 1) {
-            _.set(req.session, '404', {
+            const err = {
               message: config.content.messages.missing.revision.replace('%revision', req.params.revision).replace('%type', req.params.type).replace('%id', req.params.id),
               safe: `/${config.content.base}/${req.params.type}`,
-            });
+              status: 404,
+            };
 
-            return next();
+            return next(err);
           }
 
           // add itentifier to each row
@@ -306,12 +308,13 @@ const routes = application => {
             revision: req.params.revision,
           }).then(rows => {
             if (rows.length < 1) {
-              _.set(req.session, '404', {
+              const err = {
                 message: config.content.messages.missing.revision.replace('%type', req.params.type).replace('%id', req.params.id).replace('%revision', req.params.revision),
                 safe: `/${config.content.base}/${req.params.type}`,
-              });
+                status: 404,
+              };
 
-              return next();
+              return next(err);
             }
             data = rows[0].value;
 

--- a/lib/routes/errors.js
+++ b/lib/routes/errors.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const routes = require('../errors/routes');
 
 /*
  * Error Route Handling
@@ -21,16 +21,7 @@ module.exports = application => {
      * @param {object} res - HTTP Response
      */
     app.use((req, res) => {
-      const message = _.get(req.session, '404.message', `Not Found: ${req.url}`);
-      const safe = _.get(req.session, '404.safe');
-
-      _.unset(req.session, '404');
-
-      res.status(404);
-      res.render('404', {
-        message,
-        safe,
-      });
+      return routes.notFound(req, res);
     });
 
     /*
@@ -42,19 +33,9 @@ module.exports = application => {
      * @param {object} res - HTTP Response
      */
 
-    app.use((err, req, res) => {
-      const error = {
-        message: err.message,
-        error: {},
-      };
-
-      // If in development, will print stacktrace
-      if (app.get('env') === 'development') {
-        error.error = err;
-      }
-
-      res.status(err.status || 500);
-      res.render('error', error);
+    // eslint disabled because without next the error handler is ignored
+    app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+      return routes.errors(err, req, res, next, app);
     });
 
     resolve(app);

--- a/lib/routes/errors.js
+++ b/lib/routes/errors.js
@@ -32,9 +32,7 @@ module.exports = application => {
      * @param {object} req - HTTP Request
      * @param {object} res - HTTP Response
      */
-
-    // eslint disabled because without next the error handler is ignored
-    app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+    app.use((err, req, res, next) => {
       return routes.errors(err, req, res, next, app);
     });
 

--- a/lib/routes/errors.js
+++ b/lib/routes/errors.js
@@ -21,7 +21,7 @@ module.exports = application => {
      * @param {object} res - HTTP Response
      */
     app.use((req, res) => {
-      return routes.notFound(req, res);
+      return routes.missing(req, res);
     });
 
     /*

--- a/lib/routes/users.js
+++ b/lib/routes/users.js
@@ -109,8 +109,11 @@ const routes = application => {
 
       return database('users').where('id', req.params.id).then(rows => {
         if (rows.length < 1) {
-          res.status(404);
-          const error = new Error(`${config.users.messages.errors.edit}`);
+          const error = {
+            message: config.users.messages.errors.edit,
+            status: 404,
+            safe: '/users',
+          };
 
           return next(error);
         }
@@ -198,8 +201,11 @@ const routes = application => {
 
       return database('users').where('id', req.params.id).then(rows => {
         if (rows.length < 1) {
-          res.status(404);
-          const error = new Error(`${config.users.delete.error}`);
+          const error = {
+            message: config.users.messages.errors.delete,
+            status: 404,
+            safe: '/users',
+          };
 
           return next(error);
         }

--- a/lib/routes/users.js
+++ b/lib/routes/users.js
@@ -111,7 +111,8 @@ const routes = application => {
         if (rows.length < 1) {
           res.status(404);
           const error = new Error(`${config.users.messages.errors.edit}`);
-          res.render('error', error);
+
+          return next(error);
         }
         user = rows[0];
 

--- a/lib/routes/users.js
+++ b/lib/routes/users.js
@@ -195,14 +195,16 @@ const routes = application => {
         message = config.users.messages.errors.current;
       }
 
-      database('users').where('id', req.params.id).then(rows => {
+      return database('users').where('id', req.params.id).then(rows => {
         if (rows.length < 1) {
           res.status(404);
           const error = new Error(`${config.users.delete.error}`);
-          res.render('error', error);
+
+          return next(error);
         }
         const user = rows[0];
-        res.render('users/delete', {
+
+        return res.render('users/delete', {
           title: config.users.actions.delete,
           email: user.email,
           action: `/${config.users.base}/${config.users.actions.delete}`,
@@ -212,7 +214,7 @@ const routes = application => {
         });
       })
       .catch(error => {
-        next(error);
+        return next(error);
       });
     });
 

--- a/lib/routes/workflows.js
+++ b/lib/routes/workflows.js
@@ -71,12 +71,13 @@ const routes = application => {
           .where('id', req.params.id)
           .then(rws => {
             if (rws.length < 1) {
-              _.set(req.session, '404', {
+              const err = {
                 message: config.content.messages.missing.revision.replace('%revision', req.params.revision).replace('%type', req.params.type).replace('%id', req.params.id),
                 safe: `/${config.content.base}/${req.params.type}`,
-              });
+                status: 404,
+              };
 
-              return next();
+              return next(err);
             }
 
             // add the previous session data back in
@@ -106,12 +107,13 @@ const routes = application => {
 
             // if below zero, this content is already approved
             if (approval < 0) {
-              _.set(req.session, '404', {
+              const err = {
                 message: config.workflows.messages.approved,
                 safe: `/${config.content.base}/${req.params.type}`,
-              });
+                status: 404,
+              };
 
-              return next();
+              return next(err);
             }
 
             // grab the the next step in approval workflow

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "input-plugin-text": "0.1.0",
     "lorem-ipsum": "^1.0.3",
     "mock-express-response": "^0.1.2",
+    "node-mocks-http": "^1.5.3",
     "nyc": "^6.6.0",
     "punchcard-commit-msg": "^1.0.0",
     "punchcard-runner": "^2.1.2",

--- a/tests/errors.js
+++ b/tests/errors.js
@@ -7,9 +7,6 @@ import routes from '../lib/errors/routes';
 
 const EventEmitter = events.EventEmitter;
 
-// used in a promise below
-let nextCalled = false; // eslint-disable-line no-unused-vars
-
 const get = (req) => {
   if (req === 'env') {
     return 'development';
@@ -25,13 +22,13 @@ const app = {
 
 /**
  * Next
- * @param  {object} err - the error object
- * @returns {object} nextCalled - the error object
+ *
+ * @param {object} value object send to next
+ *
+ * @returns {object} whatever the function received
  */
-const next = (err) => {
-  nextCalled = err;
-
-  return nextCalled;
+const next = (value) => {
+  return value;
 };
 
 const err = {
@@ -44,20 +41,18 @@ const err = {
 // Routes - 404
 //////////////////////////////
 test.cb('404 error route', t => {
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
   const request = httpMocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });
 
-  request._setSessionVariable('404', {});
-
-  _.set(request.session, '404', {
+  request._setSessionVariable('404', {
     message: 'Something bad happened',
     safe: '/refreshing/safe/path',
   });
 
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
-  routes.notFound(request, response);
+  routes.missing(request, response);
 
   response.on('end', () => {
     const data = response._getRenderData();
@@ -75,16 +70,16 @@ test.cb('404 error route', t => {
 // Routes - error
 //////////////////////////////
 test.cb('General error', t => {
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
   const error = _.cloneDeep(err);
-  error.message = 'Something bad happened';
-  error.safe = '/refreshing/safe/path';
-
   const request = httpMocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });
 
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
+  error.message = 'Something bad happened';
+  error.safe = '/refreshing/safe/path';
+
   routes.errors(error, request, response, next, app);
 
   response.on('end', () => {
@@ -99,12 +94,12 @@ test.cb('General error', t => {
 });
 
 test.cb('Unknown error', t => {
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
   const request = httpMocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });
 
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
   routes.errors('', request, response, next, app);
 
   response.on('end', () => {
@@ -119,12 +114,12 @@ test.cb('Unknown error', t => {
 });
 
 test.cb('Message into error', t => {
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
   const request = httpMocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });
 
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
   routes.errors('I am error', request, response, next, app);
 
   response.on('end', () => {

--- a/tests/errors.js
+++ b/tests/errors.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import events from 'events';
-import httpMocks from 'node-mocks-http';
+import mocks from 'node-mocks-http';
 import _ from 'lodash';
 
 import routes from '../lib/errors/routes';
@@ -41,8 +41,8 @@ const err = {
 // Routes - 404
 //////////////////////////////
 test.cb('404 error route', t => {
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
-  const request = httpMocks.createRequest({
+  const response = mocks.createResponse({ eventEmitter: EventEmitter });
+  const request = mocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });
@@ -70,9 +70,9 @@ test.cb('404 error route', t => {
 // Routes - error
 //////////////////////////////
 test.cb('General error', t => {
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
+  const response = mocks.createResponse({ eventEmitter: EventEmitter });
   const error = _.cloneDeep(err);
-  const request = httpMocks.createRequest({
+  const request = mocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });
@@ -94,8 +94,8 @@ test.cb('General error', t => {
 });
 
 test.cb('Unknown error', t => {
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
-  const request = httpMocks.createRequest({
+  const response = mocks.createResponse({ eventEmitter: EventEmitter });
+  const request = mocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });
@@ -114,8 +114,8 @@ test.cb('Unknown error', t => {
 });
 
 test.cb('Message into error', t => {
-  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
-  const request = httpMocks.createRequest({
+  const response = mocks.createResponse({ eventEmitter: EventEmitter });
+  const request = mocks.createRequest({
     method: 'GET',
     url: '/some/madeup/icky/path',
   });

--- a/tests/errors.js
+++ b/tests/errors.js
@@ -1,0 +1,139 @@
+import test from 'ava';
+import events from 'events';
+import httpMocks from 'node-mocks-http';
+import _ from 'lodash';
+
+import routes from '../lib/errors/routes';
+
+const EventEmitter = events.EventEmitter;
+
+// used in a promise below
+let nextCalled = false; // eslint-disable-line no-unused-vars
+
+const get = (req) => {
+  if (req === 'env') {
+    return 'development';
+  }
+
+  return false;
+};
+
+// application fake object
+const app = {
+  get,
+};
+
+/**
+ * Next
+ * @param  {object} err - the error object
+ * @returns {object} nextCalled - the error object
+ */
+const next = (err) => {
+  nextCalled = err;
+
+  return nextCalled;
+};
+
+const err = {
+  message: '',
+  safe: '/content',
+  status: 404,
+};
+
+//////////////////////////////
+// Routes - 404
+//////////////////////////////
+test.cb('404 error route', t => {
+  const request = httpMocks.createRequest({
+    method: 'GET',
+    url: '/some/madeup/icky/path',
+  });
+
+  request._setSessionVariable('404', {});
+
+  _.set(request.session, '404', {
+    message: 'Something bad happened',
+    safe: '/refreshing/safe/path',
+  });
+
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
+  routes.notFound(request, response);
+
+  response.on('end', () => {
+    const data = response._getRenderData();
+
+    t.is(response.statusCode, 404, 'Should be a 404 response');
+    t.is(data.message, 'Something bad happened');
+    t.is(data.safe, '/refreshing/safe/path');
+    t.end();
+  });
+  response.render();
+});
+
+
+//////////////////////////////
+// Routes - error
+//////////////////////////////
+test.cb('General error', t => {
+  const error = _.cloneDeep(err);
+  error.message = 'Something bad happened';
+  error.safe = '/refreshing/safe/path';
+
+  const request = httpMocks.createRequest({
+    method: 'GET',
+    url: '/some/madeup/icky/path',
+  });
+
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
+  routes.errors(error, request, response, next, app);
+
+  response.on('end', () => {
+    const data = response._getRenderData();
+
+    t.is(response.statusCode, 404, 'Should be a 404 response');
+    t.is(data.message, 'Something bad happened');
+    t.is(data.safe, '/refreshing/safe/path');
+    t.end();
+  });
+  response.render();
+});
+
+test.cb('Unknown error', t => {
+  const request = httpMocks.createRequest({
+    method: 'GET',
+    url: '/some/madeup/icky/path',
+  });
+
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
+  routes.errors('', request, response, next, app);
+
+  response.on('end', () => {
+    const data = response._getRenderData();
+
+    t.is(response.statusCode, 500, 'Should be a 500 response');
+    t.is(data.message, 'route error');
+    t.is(data.safe, '/');
+    t.end();
+  });
+  response.render();
+});
+
+test.cb('Message into error', t => {
+  const request = httpMocks.createRequest({
+    method: 'GET',
+    url: '/some/madeup/icky/path',
+  });
+
+  const response = httpMocks.createResponse({ eventEmitter: EventEmitter });
+  routes.errors('I am error', request, response, next, app);
+
+  response.on('end', () => {
+    const data = response._getRenderData();
+
+    t.is(response.statusCode, 500, 'Should be a 500 response');
+    t.is(data.message, 'I am error');
+    t.is(data.safe, '/');
+    t.end();
+  });
+  response.render();
+});

--- a/tests/server.js
+++ b/tests/server.js
@@ -275,9 +275,9 @@ test.cb('Landing Page with Reference', t => {
 });
 
 
-//////////////////////////////
-// Content Pages - individual revision page
-//////////////////////////////
+// //////////////////////////////
+// // Content Pages - individual revision page
+// //////////////////////////////
 
 test.cb('Invalid Content Type - individual revision', t => {
   addService(service).then(revision => {
@@ -331,9 +331,9 @@ test.cb('Content Type Revision View', t => {
   });
 });
 
-//////////////////////////////
-// Content Pages - content edit page
-//////////////////////////////
+// //////////////////////////////
+// // Content Pages - content edit page
+// //////////////////////////////
 
 test.cb('Invalid Content Type - Content Type Edit Page', t => {
   addService().then(revision => {
@@ -384,53 +384,53 @@ test.cb('Non number for revision - Content Type Edit Page', t => {
     });
 });
 
-test.skip('Content Type Post data - testing session', t => {
-  const svc = (JSON.parse(JSON.stringify(service)));
-  svc[0].value = {
-    'service-name':
-    {
-      'text':
-      {
-        'value': 'This is the test title',
-      },
-    },
-    'sunset-date':
-    {
-      'value': '2016-08-08',
-    },
-  };
-  addService(svc).then(revision => {
-    agent
-      .get(`/content/services/${serviceUuid}/${revision}/edit`)
-      .set('cookie', cookie)
-      .expect(200)
-      .end((err, res) => {
-        t.is(err, null, 'Should not have an error');
-        t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
+// test.skip('Content Type Post data - testing session', t => {
+//   const svc = (JSON.parse(JSON.stringify(service)));
+//   svc[0].value = {
+//     'service-name':
+//     {
+//       'text':
+//       {
+//         'value': 'This is the test title',
+//       },
+//     },
+//     'sunset-date':
+//     {
+//       'value': '2016-08-08',
+//     },
+//   };
+//   addService(svc).then(revision => {
+//     agent
+//       .get(`/content/services/${serviceUuid}/${revision}/edit`)
+//       .set('cookie', cookie)
+//       .expect(200)
+//       .end((err, res) => {
+//         t.is(err, null, 'Should not have an error');
+//         t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
 
-        t.end();
-      });
-  });
-});
+//         t.end();
+//       });
+//   });
+// });
 
-test.skip('Content Type Edit Page', t => {
-  getService({ id: serviceUuid }).then(srvc => {
-    agent
-      .get(`/content/services/${serviceUuid}/${srvc[0].revision}/edit`)
-      .set('cookie', cookie)
-      .expect(200)
-      .end((err, res) => {
-        t.is(err, null, 'Should not have an error');
-        t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
+// test.skip('Content Type Edit Page', t => {
+//   getService({ id: serviceUuid }).then(srvc => {
+//     agent
+//       .get(`/content/services/${serviceUuid}/${srvc[0].revision}/edit`)
+//       .set('cookie', cookie)
+//       .expect(200)
+//       .end((err, res) => {
+//         t.is(err, null, 'Should not have an error');
+//         t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
 
-        t.end();
-      });
-  });
-});
+//         t.end();
+//       });
+//   });
+// });
 
-//////////////////////////////
-// Content Pages - content Post data
-//////////////////////////////
+// //////////////////////////////
+// // Content Pages - content Post data
+// //////////////////////////////
 
 test.cb('Invalid Content Type - Post data', t => {
   agent
@@ -444,19 +444,19 @@ test.cb('Invalid Content Type - Post data', t => {
     });
 });
 
-test.skip('Database error - Content Type Post data', t => {
-  agent
-    .post('/content/services/save')
-    .field('language', 'Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character')
-    .set('cookie', cookie)
-    .expect(500)
-    .end((err, res) => {
-      t.is(err, null, 'Should have an error');
-      t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
+// test.skip('Database error - Content Type Post data', t => {
+//   agent
+//     .post('/content/services/save')
+//     .field('language', 'Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character')
+//     .set('cookie', cookie)
+//     .expect(500)
+//     .end((err, res) => {
+//       t.is(err, null, 'Should have an error');
+//       t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
 
-      t.end();
-    });
-});
+//       t.end();
+//     });
+// });
 
 test.cb('Content Type Post data', t => {
   agent
@@ -474,22 +474,22 @@ test.cb('Content Type Post data', t => {
     });
 });
 
-test.skip('Content Type Post data - testing session', t => {
-  addService(service).then(revision => {
-    agent
-      .get(`/content/services/${serviceUuid}/${revision}/edit`)
-      .set('cookie', cookie)
-      .expect(200)
-      .end((err) => {
-        t.is(err, null, 'Should not have an error');
-        t.end();
-      });
-  });
-});
+// test.skip('Content Type Post data - testing session', t => {
+//   addService(service).then(revision => {
+//     agent
+//       .get(`/content/services/${serviceUuid}/${revision}/edit`)
+//       .set('cookie', cookie)
+//       .expect(200)
+//       .end((err) => {
+//         t.is(err, null, 'Should not have an error');
+//         t.end();
+//       });
+//   });
+// });
 
-//////////////////////////////
-// Content Approval - approve page
-//////////////////////////////
+// //////////////////////////////
+// // Content Approval - approve page
+// //////////////////////////////
 
 test.cb('Invalid Content Type - Content Approval Page', t => {
   addService().then(revision => {
@@ -555,9 +555,9 @@ test.cb('Content Approval Page', t => {
   });
 });
 
-//////////////////////////////
-// Content Approval - approve Post data
-//////////////////////////////
+// //////////////////////////////
+// // Content Approval - approve Post data
+// //////////////////////////////
 
 test.cb('Invalid Content Approval - Post data', t => {
   agent
@@ -571,133 +571,133 @@ test.cb('Invalid Content Approval - Post data', t => {
     });
 });
 
-test.skip('Database error - Content Approval Post data', t => {
-  agent
-    .post('/content/services/approve')
-    .field('language', 'test-dummy-entry')
-    .field('approval', 'test')
-    .set('cookie', cookie)
-    .expect(500)
-    .end((err, res) => {
-      t.is(err, null, 'Should have an error');
-      t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
+// test.skip('Database error - Content Approval Post data', t => {
+//   agent
+//     .post('/content/services/approve')
+//     .field('language', 'test-dummy-entry')
+//     .field('approval', 'test')
+//     .set('cookie', cookie)
+//     .expect(500)
+//     .end((err, res) => {
+//       t.is(err, null, 'Should have an error');
+//       t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
 
-      t.end();
-    });
-});
+//       t.end();
+//     });
+// });
 
-test.skip('Content Type Approval data', t => {
-  agent
-    .post('/content/services/save')
-    .field('language', 'test-dummy-entry')
-    .field('approval', 1)
-    .field('service-name--text', 'Picachu')
-    .set('cookie', cookie)
-    .expect(302)
-    .end((err, res) => {
-      t.is(err, null, 'Should not have an error');
-      t.is(res.text, 'Found. Redirecting to /content/services', 'should have a redirect message');
+// test.skip('Content Type Approval data', t => {
+//   agent
+//     .post('/content/services/save')
+//     .field('language', 'test-dummy-entry')
+//     .field('approval', 1)
+//     .field('service-name--text', 'Picachu')
+//     .set('cookie', cookie)
+//     .expect(302)
+//     .end((err, res) => {
+//       t.is(err, null, 'Should not have an error');
+//       t.is(res.text, 'Found. Redirecting to /content/services', 'should have a redirect message');
 
-      t.end();
-    });
-});
+//       t.end();
+//     });
+// });
 
-test.skip('Content Type Approval data - missing data: comment', t => {
-  addService(service).then(revision => {
-    agent
-      .post('/content/services/approve')
-      .send({
-        'language': 'test-dummy-entry',
-        'comment--textarea': '',
-        'action--select': 'approve',
-      })
-      .set('cookie', cookie)
-      .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
-      .expect(302)
-      .end((error, res) => {
-        t.is(error, null, 'Should not have an error');
-        t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
+// test.skip('Content Type Approval data - missing data: comment', t => {
+//   addService(service).then(revision => {
+//     agent
+//       .post('/content/services/approve')
+//       .send({
+//         'language': 'test-dummy-entry',
+//         'comment--textarea': '',
+//         'action--select': 'approve',
+//       })
+//       .set('cookie', cookie)
+//       .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
+//       .expect(302)
+//       .end((error, res) => {
+//         t.is(error, null, 'Should not have an error');
+//         t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
 
-        t.end();
-      });
-  });
-});
+//         t.end();
+//       });
+//   });
+// });
 
-test.skip('Content Type Approval data - missing data: action', t => {
-  addService(service).then(revision => {
-    agent
-      .post('/content/services/approve')
-      .send({
-        'language': 'test-dummy-entry',
-        'comment--textarea': 'I like it, kinda',
-        'action--select': '',
-      })
-      .set('cookie', cookie)
-      .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
-      .expect(302)
-      .end((error, res) => {
-        t.is(error, null, 'Should not have an error');
-        t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
+// test.skip('Content Type Approval data - missing data: action', t => {
+//   addService(service).then(revision => {
+//     agent
+//       .post('/content/services/approve')
+//       .send({
+//         'language': 'test-dummy-entry',
+//         'comment--textarea': 'I like it, kinda',
+//         'action--select': '',
+//       })
+//       .set('cookie', cookie)
+//       .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
+//       .expect(302)
+//       .end((error, res) => {
+//         t.is(error, null, 'Should not have an error');
+//         t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
 
-        t.end();
-      });
-  });
-});
+//         t.end();
+//       });
+//   });
+// });
 
-test.skip('Content Approval Post data', t => {
-  addService(service).then(revision => {
-    agent
-      .get(`/content/services/${serviceUuid}/${revision}/approve`)
-      .set('cookie', cookie)
-      .expect(200)
-      .end((err1, res1) => {
-        t.is(err1, null, 'Should not have an error');
-        t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
-        t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
+// test.skip('Content Approval Post data', t => {
+//   addService(service).then(revision => {
+//     agent
+//       .get(`/content/services/${serviceUuid}/${revision}/approve`)
+//       .set('cookie', cookie)
+//       .expect(200)
+//       .end((err1, res1) => {
+//         t.is(err1, null, 'Should not have an error');
+//         t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
+//         t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
 
-        agent
-          .post('/content/services/approve')
-          .send({
-            'comment--textarea': 'I like it, you are a winner.',
-            'action--select': 'approve',
-          })
-          .set('cookie', cookie)
-          .expect(302)
-          .end((err2, res2) => {
-            t.is(err2, null, 'Should not have an error');
-            t.true(includes(res2.text, 'Found. Redirecting to /content/services', 'should have a redirect message'));
+//         agent
+//           .post('/content/services/approve')
+//           .send({
+//             'comment--textarea': 'I like it, you are a winner.',
+//             'action--select': 'approve',
+//           })
+//           .set('cookie', cookie)
+//           .expect(302)
+//           .end((err2, res2) => {
+//             t.is(err2, null, 'Should not have an error');
+//             t.true(includes(res2.text, 'Found. Redirecting to /content/services', 'should have a redirect message'));
 
-            agent
-              .get(`/content/services/${serviceUuid}/${revision}/approve`)
-              .set('cookie', cookie)
-              .expect(200)
-              .end((err3, res3) => {
-                t.is(err3, null, 'Should not have an error');
-                t.true(includes(res3.text, 'action="/content/services/approve"'), 'should have correct form action url');
-                t.true(includes(res3.text, 'Publish</button>'), 'Should have the final button in approval step');
+//             agent
+//               .get(`/content/services/${serviceUuid}/${revision}/approve`)
+//               .set('cookie', cookie)
+//               .expect(200)
+//               .end((err3, res3) => {
+//                 t.is(err3, null, 'Should not have an error');
+//                 t.true(includes(res3.text, 'action="/content/services/approve"'), 'should have correct form action url');
+//                 t.true(includes(res3.text, 'Publish</button>'), 'Should have the final button in approval step');
 
-                t.end();
-              });
-          });
-      });
-  });
-});
+//                 t.end();
+//               });
+//           });
+//       });
+//   });
+// });
 
-test.skip('Content Approval Rejection', t => {
-  addService(service).then(revision => {
-    agent
-      .get(`/content/services/${serviceUuid}/${revision}/approve`)
-      .set('cookie', cookie)
-      .expect(200)
-      .end((err1, res1) => {
-        t.is(err1, null, 'Should not have an error');
-        t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
-        t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
+// test.skip('Content Approval Rejection', t => {
+//   addService(service).then(revision => {
+//     agent
+//       .get(`/content/services/${serviceUuid}/${revision}/approve`)
+//       .set('cookie', cookie)
+//       .expect(200)
+//       .end((err1, res1) => {
+//         t.is(err1, null, 'Should not have an error');
+//         t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
+//         t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
 
-        t.end();
-      });
-  });
-});
+//         t.end();
+//       });
+//   });
+// });
 
 //////////////////////////////
 // 404 Pages
@@ -755,7 +755,7 @@ test.cb('Users Edit Landing Page', t => {
     });
 });
 
-test.cb('Users Delete Landing Page', t => {
+test.skip('Users Delete Landing Page', t => {
   agent
     .get(`/users/${accounts[1].id}/delete`)
     .set('cookie', cookie)

--- a/tests/server.js
+++ b/tests/server.js
@@ -755,7 +755,7 @@ test.cb('Users Edit Landing Page', t => {
     });
 });
 
-test.skip('Users Delete Landing Page', t => {
+test.cb('Users Delete Landing Page', t => {
   agent
     .get(`/users/${accounts[1].id}/delete`)
     .set('cookie', cookie)

--- a/tests/server.js
+++ b/tests/server.js
@@ -275,9 +275,9 @@ test.cb('Landing Page with Reference', t => {
 });
 
 
-// //////////////////////////////
-// // Content Pages - individual revision page
-// //////////////////////////////
+//////////////////////////////
+// Content Pages - individual revision page
+//////////////////////////////
 
 test.cb('Invalid Content Type - individual revision', t => {
   addService(service).then(revision => {
@@ -331,9 +331,9 @@ test.cb('Content Type Revision View', t => {
   });
 });
 
-// //////////////////////////////
-// // Content Pages - content edit page
-// //////////////////////////////
+//////////////////////////////
+// Content Pages - content edit page
+//////////////////////////////
 
 test.cb('Invalid Content Type - Content Type Edit Page', t => {
   addService().then(revision => {
@@ -384,53 +384,53 @@ test.cb('Non number for revision - Content Type Edit Page', t => {
     });
 });
 
-// test.skip('Content Type Post data - testing session', t => {
-//   const svc = (JSON.parse(JSON.stringify(service)));
-//   svc[0].value = {
-//     'service-name':
-//     {
-//       'text':
-//       {
-//         'value': 'This is the test title',
-//       },
-//     },
-//     'sunset-date':
-//     {
-//       'value': '2016-08-08',
-//     },
-//   };
-//   addService(svc).then(revision => {
-//     agent
-//       .get(`/content/services/${serviceUuid}/${revision}/edit`)
-//       .set('cookie', cookie)
-//       .expect(200)
-//       .end((err, res) => {
-//         t.is(err, null, 'Should not have an error');
-//         t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
+test.skip('Content Type Post data - testing session', t => {
+  const svc = (JSON.parse(JSON.stringify(service)));
+  svc[0].value = {
+    'service-name':
+    {
+      'text':
+      {
+        'value': 'This is the test title',
+      },
+    },
+    'sunset-date':
+    {
+      'value': '2016-08-08',
+    },
+  };
+  addService(svc).then(revision => {
+    agent
+      .get(`/content/services/${serviceUuid}/${revision}/edit`)
+      .set('cookie', cookie)
+      .expect(200)
+      .end((err, res) => {
+        t.is(err, null, 'Should not have an error');
+        t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
 
-//         t.end();
-//       });
-//   });
-// });
+        t.end();
+      });
+  });
+});
 
-// test.skip('Content Type Edit Page', t => {
-//   getService({ id: serviceUuid }).then(srvc => {
-//     agent
-//       .get(`/content/services/${serviceUuid}/${srvc[0].revision}/edit`)
-//       .set('cookie', cookie)
-//       .expect(200)
-//       .end((err, res) => {
-//         t.is(err, null, 'Should not have an error');
-//         t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
+test.skip('Content Type Edit Page', t => {
+  getService({ id: serviceUuid }).then(srvc => {
+    agent
+      .get(`/content/services/${serviceUuid}/${srvc[0].revision}/edit`)
+      .set('cookie', cookie)
+      .expect(200)
+      .end((err, res) => {
+        t.is(err, null, 'Should not have an error');
+        t.regex(res.text, /DOCTYPE html/, 'should have an html doctype');
 
-//         t.end();
-//       });
-//   });
-// });
+        t.end();
+      });
+  });
+});
 
-// //////////////////////////////
-// // Content Pages - content Post data
-// //////////////////////////////
+//////////////////////////////
+// Content Pages - content Post data
+//////////////////////////////
 
 test.cb('Invalid Content Type - Post data', t => {
   agent
@@ -444,19 +444,19 @@ test.cb('Invalid Content Type - Post data', t => {
     });
 });
 
-// test.skip('Database error - Content Type Post data', t => {
-//   agent
-//     .post('/content/services/save')
-//     .field('language', 'Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character')
-//     .set('cookie', cookie)
-//     .expect(500)
-//     .end((err, res) => {
-//       t.is(err, null, 'Should have an error');
-//       t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
+test.skip('Database error - Content Type Post data', t => {
+  agent
+    .post('/content/services/save')
+    .field('language', 'Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character Character')
+    .set('cookie', cookie)
+    .expect(500)
+    .end((err, res) => {
+      t.is(err, null, 'Should have an error');
+      t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
 
-//       t.end();
-//     });
-// });
+      t.end();
+    });
+});
 
 test.cb('Content Type Post data', t => {
   agent
@@ -474,22 +474,22 @@ test.cb('Content Type Post data', t => {
     });
 });
 
-// test.skip('Content Type Post data - testing session', t => {
-//   addService(service).then(revision => {
-//     agent
-//       .get(`/content/services/${serviceUuid}/${revision}/edit`)
-//       .set('cookie', cookie)
-//       .expect(200)
-//       .end((err) => {
-//         t.is(err, null, 'Should not have an error');
-//         t.end();
-//       });
-//   });
-// });
+test.skip('Content Type Post data - testing session', t => {
+  addService(service).then(revision => {
+    agent
+      .get(`/content/services/${serviceUuid}/${revision}/edit`)
+      .set('cookie', cookie)
+      .expect(200)
+      .end((err) => {
+        t.is(err, null, 'Should not have an error');
+        t.end();
+      });
+  });
+});
 
-// //////////////////////////////
-// // Content Approval - approve page
-// //////////////////////////////
+//////////////////////////////
+// Content Approval - approve page
+//////////////////////////////
 
 test.cb('Invalid Content Type - Content Approval Page', t => {
   addService().then(revision => {
@@ -571,133 +571,133 @@ test.cb('Invalid Content Approval - Post data', t => {
     });
 });
 
-// test.skip('Database error - Content Approval Post data', t => {
-//   agent
-//     .post('/content/services/approve')
-//     .field('language', 'test-dummy-entry')
-//     .field('approval', 'test')
-//     .set('cookie', cookie)
-//     .expect(500)
-//     .end((err, res) => {
-//       t.is(err, null, 'Should have an error');
-//       t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
+test.skip('Database error - Content Approval Post data', t => {
+  agent
+    .post('/content/services/approve')
+    .field('language', 'test-dummy-entry')
+    .field('approval', 'test')
+    .set('cookie', cookie)
+    .expect(500)
+    .end((err, res) => {
+      t.is(err, null, 'Should have an error');
+      t.true(includes(res.text, 'error: insert into &quot;content-type--services&quot;', 'should have an error message'));
 
-//       t.end();
-//     });
-// });
+      t.end();
+    });
+});
 
-// test.skip('Content Type Approval data', t => {
-//   agent
-//     .post('/content/services/save')
-//     .field('language', 'test-dummy-entry')
-//     .field('approval', 1)
-//     .field('service-name--text', 'Picachu')
-//     .set('cookie', cookie)
-//     .expect(302)
-//     .end((err, res) => {
-//       t.is(err, null, 'Should not have an error');
-//       t.is(res.text, 'Found. Redirecting to /content/services', 'should have a redirect message');
+test.skip('Content Type Approval data', t => {
+  agent
+    .post('/content/services/save')
+    .field('language', 'test-dummy-entry')
+    .field('approval', 1)
+    .field('service-name--text', 'Picachu')
+    .set('cookie', cookie)
+    .expect(302)
+    .end((err, res) => {
+      t.is(err, null, 'Should not have an error');
+      t.is(res.text, 'Found. Redirecting to /content/services', 'should have a redirect message');
 
-//       t.end();
-//     });
-// });
+      t.end();
+    });
+});
 
-// test.skip('Content Type Approval data - missing data: comment', t => {
-//   addService(service).then(revision => {
-//     agent
-//       .post('/content/services/approve')
-//       .send({
-//         'language': 'test-dummy-entry',
-//         'comment--textarea': '',
-//         'action--select': 'approve',
-//       })
-//       .set('cookie', cookie)
-//       .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
-//       .expect(302)
-//       .end((error, res) => {
-//         t.is(error, null, 'Should not have an error');
-//         t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
+test.skip('Content Type Approval data - missing data: comment', t => {
+  addService(service).then(revision => {
+    agent
+      .post('/content/services/approve')
+      .send({
+        'language': 'test-dummy-entry',
+        'comment--textarea': '',
+        'action--select': 'approve',
+      })
+      .set('cookie', cookie)
+      .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
+      .expect(302)
+      .end((error, res) => {
+        t.is(error, null, 'Should not have an error');
+        t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
 
-//         t.end();
-//       });
-//   });
-// });
+        t.end();
+      });
+  });
+});
 
-// test.skip('Content Type Approval data - missing data: action', t => {
-//   addService(service).then(revision => {
-//     agent
-//       .post('/content/services/approve')
-//       .send({
-//         'language': 'test-dummy-entry',
-//         'comment--textarea': 'I like it, kinda',
-//         'action--select': '',
-//       })
-//       .set('cookie', cookie)
-//       .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
-//       .expect(302)
-//       .end((error, res) => {
-//         t.is(error, null, 'Should not have an error');
-//         t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
+test.skip('Content Type Approval data - missing data: action', t => {
+  addService(service).then(revision => {
+    agent
+      .post('/content/services/approve')
+      .send({
+        'language': 'test-dummy-entry',
+        'comment--textarea': 'I like it, kinda',
+        'action--select': '',
+      })
+      .set('cookie', cookie)
+      .set('Referrer', `/content/services/${serviceUuid}/${revision}/approve`)
+      .expect(302)
+      .end((error, res) => {
+        t.is(error, null, 'Should not have an error');
+        t.true(includes(res.text, `Found. Redirecting to /content/services/${serviceUuid}/${revision}/approve`, 'should have a redirect message'));
 
-//         t.end();
-//       });
-//   });
-// });
+        t.end();
+      });
+  });
+});
 
-// test.skip('Content Approval Post data', t => {
-//   addService(service).then(revision => {
-//     agent
-//       .get(`/content/services/${serviceUuid}/${revision}/approve`)
-//       .set('cookie', cookie)
-//       .expect(200)
-//       .end((err1, res1) => {
-//         t.is(err1, null, 'Should not have an error');
-//         t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
-//         t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
+test.skip('Content Approval Post data', t => {
+  addService(service).then(revision => {
+    agent
+      .get(`/content/services/${serviceUuid}/${revision}/approve`)
+      .set('cookie', cookie)
+      .expect(200)
+      .end((err1, res1) => {
+        t.is(err1, null, 'Should not have an error');
+        t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
+        t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
 
-//         agent
-//           .post('/content/services/approve')
-//           .send({
-//             'comment--textarea': 'I like it, you are a winner.',
-//             'action--select': 'approve',
-//           })
-//           .set('cookie', cookie)
-//           .expect(302)
-//           .end((err2, res2) => {
-//             t.is(err2, null, 'Should not have an error');
-//             t.true(includes(res2.text, 'Found. Redirecting to /content/services', 'should have a redirect message'));
+        agent
+          .post('/content/services/approve')
+          .send({
+            'comment--textarea': 'I like it, you are a winner.',
+            'action--select': 'approve',
+          })
+          .set('cookie', cookie)
+          .expect(302)
+          .end((err2, res2) => {
+            t.is(err2, null, 'Should not have an error');
+            t.true(includes(res2.text, 'Found. Redirecting to /content/services', 'should have a redirect message'));
 
-//             agent
-//               .get(`/content/services/${serviceUuid}/${revision}/approve`)
-//               .set('cookie', cookie)
-//               .expect(200)
-//               .end((err3, res3) => {
-//                 t.is(err3, null, 'Should not have an error');
-//                 t.true(includes(res3.text, 'action="/content/services/approve"'), 'should have correct form action url');
-//                 t.true(includes(res3.text, 'Publish</button>'), 'Should have the final button in approval step');
+            agent
+              .get(`/content/services/${serviceUuid}/${revision}/approve`)
+              .set('cookie', cookie)
+              .expect(200)
+              .end((err3, res3) => {
+                t.is(err3, null, 'Should not have an error');
+                t.true(includes(res3.text, 'action="/content/services/approve"'), 'should have correct form action url');
+                t.true(includes(res3.text, 'Publish</button>'), 'Should have the final button in approval step');
 
-//                 t.end();
-//               });
-//           });
-//       });
-//   });
-// });
+                t.end();
+              });
+          });
+      });
+  });
+});
 
-// test.skip('Content Approval Rejection', t => {
-//   addService(service).then(revision => {
-//     agent
-//       .get(`/content/services/${serviceUuid}/${revision}/approve`)
-//       .set('cookie', cookie)
-//       .expect(200)
-//       .end((err1, res1) => {
-//         t.is(err1, null, 'Should not have an error');
-//         t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
-//         t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
+test.skip('Content Approval Rejection', t => {
+  addService(service).then(revision => {
+    agent
+      .get(`/content/services/${serviceUuid}/${revision}/approve`)
+      .set('cookie', cookie)
+      .expect(200)
+      .end((err1, res1) => {
+        t.is(err1, null, 'Should not have an error');
+        t.true(includes(res1.text, 'action="/content/services/approve"'), 'should have correct form action url');
+        t.true(includes(res1.text, 'Send to Editor</button>'), 'Should have the first button in approval step');
 
-//         t.end();
-//       });
-//   });
-// });
+        t.end();
+      });
+  });
+});
 
 //////////////////////////////
 // 404 Pages

--- a/tests/server.js
+++ b/tests/server.js
@@ -555,9 +555,9 @@ test.cb('Content Approval Page', t => {
   });
 });
 
-// //////////////////////////////
-// // Content Approval - approve Post data
-// //////////////////////////////
+//////////////////////////////
+// Content Approval - approve Post data
+//////////////////////////////
 
 test.cb('Invalid Content Approval - Post data', t => {
   agent

--- a/views/error.html
+++ b/views/error.html
@@ -1,8 +1,11 @@
-<h1 class="base--h1">I'm error!</h1>
+<div class="not-found">
+  <img src="/images/punchcard-404.svg" class="not-found--svg" alt="Punchcard 404, Page Not Found">
+  <h2 class="not-found--h2">{{message}}</h1>
+  {% if error %}
+  <div class="not-found--error">{{error | dump}}</div>
+  {% endif %}
 
-<dl class="base--dl">
-  <dt class="base--dt">Error Message</dt>
-  <dd class="base--dd">{{message}}</dd>
-  <dt class="base--dd">Full Error</dt>
-  <dd class="base--dd">{{error}}</dd>
-</dl>
+  {% if safe %}
+  <p class="not-found--p">You could try <a href="{{safe}}" class="not-found--link">{{safe}}</a></p>
+  {% endif %}
+</div>


### PR DESCRIPTION
This covers a bug which makes our app ignore the error route we created. Instead it uses Express' built in error route page currently.

Also upgrading error routes to be more test-able! What fun!

---
Resolves #312

`DCO 1.1 Signed-off-by: Scott Nath <github@scottnath.com>`

