### PR TITLE
Add Greenkeeper label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -43,6 +43,7 @@ mindless:
     - technical debt
     - experience debt
     - tests
+    - greenkeeper
 feedback:
   description: Issues that require further conversation to figure out how to proceed or what action steps are needed.
   color: '#db2780'


### PR DESCRIPTION
Seem to have lost the greenkeeper label, adding it back

`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`

