### PR TITLE
Add missing Performance label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -28,6 +28,7 @@ experience:
     - microcopy
     - user experience
     - developer experience
+    - performance
 environment:
   description: 'Environment that the issue is present in, either Punchcard core or its use as a module'
   color: '#e9e0e0'


### PR DESCRIPTION
We need a performance label. Related to #463

---
`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`

