### PR TITLE
tests for api depth

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "ava": {
     "files": [
-      "tests/apis.js"
+      "tests/*.js"
     ],
     "failFast": false,
     "tap": false

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "input-plugin-textarea": "^0.1.3",
     "input-plugin-url": "^0.3.0",
     "js-yaml": "^3.6.1",
-    "knex": "^0.12.1",
+    "knex": "^0.12.6",
     "lodash": "^4.13.1",
     "modularscale-sass": "^2.1.1",
     "moment": "^2.15.0",
@@ -123,7 +123,7 @@
   },
   "ava": {
     "files": [
-      "tests/*.js"
+      "tests/apis.js"
     ],
     "failFast": false,
     "tap": false

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -203,7 +203,7 @@ test.serial.skip('Utils: Format Results - List', t => {
 
   return formatted.then(result => {
     result.forEach(item => {
-      utils.attribute(t, item);
+      utils.formatted(t, item);
     });
   });
 });
@@ -224,7 +224,7 @@ test.serial.skip('Utils: Format Results - no query', t => {
 
   return formatted.then(result => {
     result.forEach(itm => {
-      utils.attribute(t, itm);
+      utils.formatted(t, itm);
     });
   });
 });
@@ -248,7 +248,7 @@ test.serial.skip('Utils: Format Results - query depth zero', t => {
 
   return formatted.then(result => {
     result.forEach(itm => {
-      utils.attribute(t, itm);
+      utils.formatted(t, itm);
     });
   });
 });
@@ -272,17 +272,17 @@ test.serial.skip('Utils: Format Results - query depth one', t => {
 
   return formatted.then(result => {
     result.forEach(itm => {
-      utils.attribute(t, itm);
+      utils.formatted(t, itm);
       t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
 
       Object.keys(itm.attributes).forEach(attr => {
         if (attr.split('-').indexOf('referencer') > -1) {
           if (itm.attributes[attr].hasOwnProperty('id')) {
-            utils.attribute(t, itm.attributes[attr]);
+            utils.formatted(t, itm.attributes[attr]);
           }
           else if (!Array.isArray(itm.attributes[attr])) {
             Object.keys(itm.attributes[attr]).forEach(atr => {
-              utils.attribute(t, itm.attributes[attr][atr]);
+              utils.formatted(t, itm.attributes[attr][atr]);
             });
           }
         }
@@ -310,21 +310,21 @@ test.serial.skip('Utils: Format Results - query depth two', t => {
 
   return formatted.then(result => {
     result.forEach(itm => {
-      utils.attribute(t, itm);
+      utils.formatted(t, itm);
       t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
 
       Object.keys(itm.attributes).forEach(attr => {
         if (attr.split('-').indexOf('referencer') > -1) {
           if (itm.attributes[attr].hasOwnProperty('id')) {
-            utils.attribute(t, itm.attributes[attr]);
+            utils.formatted(t, itm.attributes[attr]);
             Object.keys(itm.attributes[attr]).forEach(atr => {
               if (atr.split('-').indexOf('referencer') > -1) {
                 if (itm.attributes[attr][atr].hasOwnProperty('id')) {
-                  utils.attribute(t, itm.attributes[attr][atr]);
+                  utils.formatted(t, itm.attributes[attr][atr]);
                 }
                 else if (!Array.isArray(itm.attributes[attr][atr])) {
                   Object.keys(itm.attributes[attr][atr]).forEach(ar => {
-                    utils.attribute(t, itm.attributes[attr][atr][ar]);
+                    utils.formatted(t, itm.attributes[attr][atr][ar]);
                   });
                 }
               }
@@ -332,7 +332,7 @@ test.serial.skip('Utils: Format Results - query depth two', t => {
           }
           else if (!Array.isArray(itm.attributes[attr])) {
             Object.keys(itm.attributes[attr]).forEach(atr => {
-              utils.attribute(t, itm.attributes[attr][atr]);
+              utils.formatted(t, itm.attributes[attr][atr]);
             });
           }
         }
@@ -594,7 +594,7 @@ test.serial.skip('API: All with Follow', t => {
       // Ignore empty object
       if (Object.keys(item).length !== 0) {
         one = true;
-        utils.attribute(t, item);
+        utils.formatted(t, item);
       }
     });
     t.true(results.hasOwnProperty('items'), 'Has Items');
@@ -673,7 +673,7 @@ test.serial.skip('API: ofType with Follow', t => {
       // Ignore empty object
       if (Object.keys(itm).length !== 0) {
         one = true;
-        utils.attribute(t, itm);
+        utils.formatted(t, itm);
       }
     });
     t.true(results.hasOwnProperty('items'), 'Has Items');

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -2,12 +2,11 @@ import test from 'ava';
 import slugify from 'underscore.string/slugify';
 import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
-import isUUID from 'validator/lib/isUUID';
 
 import apiUtils from '../lib/api/utils';
 import api from '../lib/api';
 import database from '../lib/database';
-import utils from './fixtures/_utils';
+import utils from './fixtures';
 
 const generated = 17;
 const lang = 'api-test';
@@ -36,7 +35,7 @@ test.cb.before(t => {
   });
 });
 
-test.cb.after.always(t => {
+test.cb.after(t => {
   const items = types.map(type => {
     return database('live').where('type', type).del().then(() => {
       return database('schedule').where('type', type).del();
@@ -52,80 +51,302 @@ test.cb.after.always(t => {
     });
 });
 
+/**
+ * Tests attributes with references
+ * @param  {object} t - ava testing
+ * @param  {object|array} attrs object containing attributes to test
+ *
+ * @return {null} returns nothing
+ */
+const referencerTests = (t, attrs) => {
+  if (typeof attrs !== 'object' || attrs === undefined) {
+    return;
+  }
+
+  if (attrs.hasOwnProperty('attributes')) {
+    referencerTests(t, attrs.attributes);
+
+    return;
+  }
+
+  if (Array.isArray(attrs)) {
+    attrs.forEach(attr => {
+      Object.keys(attr).forEach(atr => {
+        if (attr[atr].hasOwnProperty('attributes')) {
+          referencerTests(t, attr[atr].attributes);
+
+          return;
+        }
+        else if (attr[atr].hasOwnProperty('id')) {
+          t.true(attr[atr].hasOwnProperty('meta'), 'attribute in array contains meta');
+
+          return;
+        }
+      });
+    });
+  }
+
+  // check if this object is an attribute object
+  if (Object.keys(attrs).indexOf('id') !== -1) {
+    t.true(attrs.poo.hasOwnProperty('meta'), 'attribute in array contains meta');
+
+    return;
+  }
+
+  Object.keys(attrs).forEach(attr => {
+    if (attr.split('-').indexOf('referencer') > -1) {
+      const item = attrs[attr];
+
+      // if item has attributes
+      if (item.hasOwnProperty('attributes')) {
+        referencerTests(t, item.attributes);
+
+        return;
+      }
+
+      // if it's an array, recurseit!
+      if (Array.isArray(item)) {
+        referencerTests(t, item);
+
+        return;
+      }
+
+      if (typeof item === 'object' && typeof item[Object.keys(item)[0]] === 'object' && item[Object.keys(item)[0]].hasOwnProperty('attributes')) {
+        referencerTests(t, item.attributes);
+
+        return;
+      }
+
+      if (Object.keys(item).indexOf('id') === -1 && Object.keys(item).length >= 1) {
+        Object.keys(item).forEach(itm => {
+          t.true(item[itm].hasOwnProperty('meta'), 'attribute in array contains meta');
+
+          return;
+        });
+      }
+
+      // non-repeatable; single input
+      else {
+        t.true(item.hasOwnProperty('meta'), 'attribute in array contains meta');
+
+        return;
+      }
+    }
+  });
+};
+
 //////////////////////////////
 // Utils - attributes
 //////////////////////////////
-test('Utils: attributes', t => {
-  const item = Math.round(Math.random() * (content.length - 1));
-  let expected = content[item];
+test.serial.skip('Utils: attributes - empty query', t => {
+  const random = Math.round(Math.random() * live.length - 1);
+  let expected = live[random];
   if (expected === undefined) {
-    expected = cloneDeep(content[(content.length - 1)]);
+    expected = cloneDeep(live[(live.length - 1)]);
   }
 
   const model = allTypes.find(typ => {
     return typ.id === expected['type-slug'];
   });
 
-  const attributes = apiUtils.attributes(expected.value, model.attributes);
+  const query = {};
 
-  t.is(typeof attributes, 'object', 'Should return an object.');
-  Object.keys(attributes).map(key => {
-    const attr = key.split('-');
-    if (attr[attr.length - 1] === 'referencer') {
-      if (attributes[key] !== '') {
-        t.true(isUUID(attributes[key]), 'includes a uuid');
-      }
+  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+
+  return attributes.then(result => {
+    t.is(typeof result, 'object', 'Should contain result, an object.');
+    t.is(Object.keys(result).length, 6, 'Should contain six main objects.');
+
+    referencerTests(t, result);
+  })
+  .catch(e => {
+    console.log(e); // eslint-disable-line no-console
+  });
+});
+
+test.serial.skip('Utils: attributes - depth 0', t => {
+  const random = Math.round(Math.random() * live.length - 1);
+  let expected = live[random];
+  if (expected === undefined) {
+    expected = cloneDeep(live[(live.length - 1)]);
+  }
+
+  const model = allTypes.find(typ => {
+    return typ.id === expected['type-slug'];
+  });
+
+  // because depth is checked during attributes, depth 1 and 0 are the same for the attributes function
+  const query = {
+    depth: 0,
+  };
+
+  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+
+  return attributes.then(result => {
+    t.is(typeof result, 'object', 'Should contain result, an object.');
+
+    referencerTests(t, result);
+  })
+  .catch(e => {
+    console.log(e); // eslint-disable-line no-console
+  });
+});
+
+test.serial.skip('Utils: attributes - depth 1', t => {
+  const random = Math.round(Math.random() * live.length - 1);
+  let expected = live[random];
+  if (expected === undefined) {
+    expected = cloneDeep(live[(live.length - 1)]);
+  }
+
+  const model = allTypes.find(typ => {
+    return typ.id === expected['type-slug'];
+  });
+
+  // because depth is checked during attributes, depth 1 and 0 are the same for the attributes function
+  const query = {
+    depth: 1,
+  };
+
+  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+
+  return attributes.then(result => {
+    t.is(typeof result, 'object', 'Should contain result, an object.');
+
+    referencerTests(t, result);
+  })
+  .catch(e => {
+    console.log(e); // eslint-disable-line no-console
+  });
+});
+
+test.serial.skip('Utils: attributes - depth 2', t => {
+  const random = Math.round(Math.random() * live.length - 1);
+  let expected = live[random];
+  if (expected === undefined) {
+    expected = cloneDeep(live[(live.length - 1)]);
+  }
+
+  const model = allTypes.find(typ => {
+    return typ.id === expected['type-slug'];
+  });
+
+  const query = {
+    depth: 2,
+  };
+
+  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+
+  return attributes.then(result => {
+    t.is(typeof result, 'object', 'Should contain result, an object.');
+
+    Object.keys(result).forEach(key => {
+      referencerTests(t, result[key]);
+    });
+  })
+  .catch(e => {
+    console.log(e); // eslint-disable-line no-console
+  });
+});
+
+test.serial.skip('Utils: attributes - no references', t => {
+  const random = Math.round(Math.random() * live.length - 1);
+  let expected = live[random];
+  if (expected === undefined) {
+    expected = cloneDeep(live[(live.length - 1)]);
+  }
+
+  Object.keys(expected.attributes).forEach(attr => {
+    if (attr.split('-').indexOf('referencer') > -1) {
+      delete expected.attributes[attr];
     }
+  });
+
+  const model = allTypes.find(typ => {
+    return typ.id === expected['type-slug'];
+  });
+
+  let modelattrs = cloneDeep(model.attributes);
+  modelattrs = modelattrs.map(attr => {
+    if (attr.id.split('-').indexOf('referencer') < 0) {
+      return attr;
+    }
+
+    return false;
+  }).filter(attr => {
+    return attr !== false;
+  });
+
+  // because depth is checked during attributes, depth 1 and 0 are the same for the attributes function
+  const query = {
+    depth: 0,
+  };
+
+  const attributes = apiUtils.attributes(expected.attributes, modelattrs, allTypes, query);
+
+  return attributes.then(result => {
+    t.is(typeof result, 'object', 'Should contain result, an object.');
+    t.is(Object.keys(result).length, 2, 'Should contain two main objects.');
+  })
+  .catch(e => {
+    console.log(e); // eslint-disable-line no-console
   });
 });
 
 //////////////////////////////
 // Utils - format
 //////////////////////////////
-test('Utils: Format Results - List', t => {
-  const formatted = apiUtils.format(content.slice(0, 9));
+test.serial.skip('Utils: Format Results - List', t => {
+  const formatted = apiUtils.format(live.slice(0, 9));
 
-  formatted.forEach(item => {
-    t.true(item.hasOwnProperty('id'), 'Contains ID');
-    t.true(item.hasOwnProperty('type'), 'Contains Type');
-    t.true(item.hasOwnProperty('type_slug'), 'Contains Type Slug');
-    t.true(item.hasOwnProperty('key'), 'Contains Key');
-    t.true(item.hasOwnProperty('key_slug'), 'Contains Key Slug');
-    t.true(item.hasOwnProperty('meta'), 'Contains Meta');
-    t.false(item.hasOwnProperty('attributes'), 'Does not contain attributes');
-    t.is(item.meta.url, `/api/types/${item.type_slug}/${item.id}`, 'URL points to full content item');
+  return formatted.then(result => {
+    result.forEach(item => {
+      t.true(item.hasOwnProperty('id'), 'Contains ID');
+      t.true(item.hasOwnProperty('type'), 'Contains Type');
+      t.true(item.hasOwnProperty('type_slug'), 'Contains Type Slug');
+      t.true(item.hasOwnProperty('key'), 'Contains Key');
+      t.true(item.hasOwnProperty('key_slug'), 'Contains Key Slug');
+      t.true(item.hasOwnProperty('meta'), 'Contains Meta');
+      t.false(item.hasOwnProperty('attributes'), 'Does not contain attributes');
+      t.is(item.meta.url, `/api/types/${item.type_slug}/${item.id}`, 'URL points to full content item');
+    });
   });
 });
 
-test('Utils: Format Results - Attributes', t => {
-  const item = Math.round(Math.random() * (content.length - 1));
-  let expected = cloneDeep(content[item]);
+test.serial.skip('Utils: Format Results - Attributes', t => {
+  const query = {
+    depth: 2,
+  };
+  const item = Math.round(Math.random() * (live.length - 1));
+  let expected = cloneDeep(live[item]);
 
   if (expected === undefined) {
-    expected = cloneDeep(content[(content.length - 1)]);
+    expected = cloneDeep(live[(live.length - 1)]);
   }
 
   const model = allTypes.find(typ => {
     return typ.id === expected['type-slug'];
   });
 
-  const formatted = apiUtils.format([expected], model.attributes);
+  const formatted = apiUtils.format([expected], model.attributes, allTypes, query);
 
-  formatted.forEach(itm => {
-    t.true(itm.hasOwnProperty('id'), 'Contains ID');
-    t.true(itm.hasOwnProperty('type'), 'Contains Type');
-    t.true(itm.hasOwnProperty('type_slug'), 'Contains Type Slug');
-    t.true(itm.hasOwnProperty('key'), 'Contains Key');
-    t.true(itm.hasOwnProperty('key_slug'), 'Contains Key Slug');
-    t.false(itm.hasOwnProperty('meta'), 'Does not contain Meta');
-    t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
+  return formatted.then(result => {
+    result.forEach(itm => {
+      t.true(itm.hasOwnProperty('id'), 'Contains ID');
+      t.true(itm.hasOwnProperty('type'), 'Contains Type');
+      t.true(itm.hasOwnProperty('type_slug'), 'Contains Type Slug');
+      t.true(itm.hasOwnProperty('key'), 'Contains Key');
+      t.true(itm.hasOwnProperty('key_slug'), 'Contains Key Slug');
+      t.false(itm.hasOwnProperty('meta'), 'Does not contain Meta');
+      t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
+    });
   });
 });
 
 //////////////////////////////
 // Utils - organize
 //////////////////////////////
-test('Utils: Organize - Default', t => {
+test.serial('Utils: Organize - Default', t => {
   const actual = apiUtils.organize();
   const expected = {
     sort: {
@@ -142,7 +363,7 @@ test('Utils: Organize - Default', t => {
   t.deepEqual(actual, expected, 'Returns defaults');
 });
 
-test('Utils: Organize - Lookup', t => {
+test.serial('Utils: Organize - Lookup', t => {
   const actual = apiUtils.organize({}, [
     'foo',
     'bar',
@@ -163,7 +384,7 @@ test('Utils: Organize - Lookup', t => {
   t.deepEqual(actual, expected, 'Returns defaults');
 });
 
-test('Utils: Organize - Bad Lookup', t => {
+test.serial('Utils: Organize - Bad Lookup', t => {
   const actual = apiUtils.organize({}, {});
   const expected = {
     sort: {
@@ -180,7 +401,7 @@ test('Utils: Organize - Bad Lookup', t => {
   t.deepEqual(actual, expected, 'Returns defaults');
 });
 
-test('Utils: Organize - Custom', t => {
+test.serial('Utils: Organize - Custom', t => {
   const actual = apiUtils.organize({
     sort: 'type',
     sort_dir: 'desc', // eslint-disable-line camelcase
@@ -203,7 +424,7 @@ test('Utils: Organize - Custom', t => {
   t.deepEqual(actual, expected, 'Returns defaults');
 });
 
-test('Utils: Organize - Wrong', t => {
+test.serial('Utils: Organize - Wrong', t => {
   const actual = apiUtils.organize({
     sort: 'foo',
     sort_dir: 'banana', // eslint-disable-line camelcase
@@ -226,7 +447,7 @@ test('Utils: Organize - Wrong', t => {
   t.deepEqual(actual, expected, 'Returns defaults');
 });
 
-test('Utils: Organize - Wrong Pages', t => {
+test.serial('Utils: Organize - Wrong Pages', t => {
   const actual = apiUtils.organize({
     page: -1,
     per_page: -1, // eslint-disable-line camelcase
@@ -250,7 +471,7 @@ test('Utils: Organize - Wrong Pages', t => {
 //////////////////////////////
 // Utils - page
 //////////////////////////////
-test('Utils: Page - First', t => {
+test.serial('Utils: Page - First', t => {
   const organized = apiUtils.organize();
   const actual = apiUtils.page('api', organized, 100);
 
@@ -265,7 +486,7 @@ test('Utils: Page - First', t => {
   t.deepEqual(actual, expected);
 });
 
-test('Utils: Page - Middle', t => {
+test.serial('Utils: Page - Middle', t => {
   const organized = apiUtils.organize({
     page: 2,
   });
@@ -282,7 +503,7 @@ test('Utils: Page - Middle', t => {
   t.deepEqual(actual, expected);
 });
 
-test('Utils: Page - End', t => {
+test.serial('Utils: Page - End', t => {
   const organized = apiUtils.organize({
     page: 4,
   });
@@ -299,7 +520,7 @@ test('Utils: Page - End', t => {
   t.deepEqual(actual, expected);
 });
 
-test('Utils: Page - One', t => {
+test.serial('Utils: Page - One', t => {
   const organized = apiUtils.organize({
     page: 1,
   });
@@ -316,7 +537,7 @@ test('Utils: Page - One', t => {
   t.deepEqual(actual, expected);
 });
 
-test('Utils: Page - None', t => {
+test.serial('Utils: Page - None', t => {
   const organized = apiUtils.organize({
     page: 4,
   });
@@ -336,7 +557,7 @@ test('Utils: Page - None', t => {
 //////////////////////////////
 // APIs
 //////////////////////////////
-test('APIs: Types', t => {
+test.serial('APIs: Types', t => {
   const app = {
     get: () => {
       return allTypes;
@@ -356,17 +577,18 @@ test('APIs: Types', t => {
   t.true(isEqual(apiTypes.keys, keys), 'Keys are as expected');
 });
 
-test('API: All', t => {
-  return api.all({}).then(results => {
+test.serial('API: All', t => {
+  return api.all({}, allTypes).then(results => {
     t.true(results.hasOwnProperty('items'), 'Has Items');
     t.true(results.hasOwnProperty('pages'), 'Has Pagination');
     t.true(results.items.length >= generated, 'Has at least all items in it');
   });
 });
 
-test('API: All with Follow', t => {
+test.serial.skip('API: All with Follow', t => {
   return api.all({
     follow: 'true',
+    depth: 1,
   }, allTypes).then(results => {
     let one = false;
 
@@ -394,7 +616,7 @@ test('API: All with Follow', t => {
   });
 });
 
-test('API: Content', t => {
+test.serial('API: Content', t => {
   const app = {
     get: () => {
       return allTypes;
@@ -410,7 +632,7 @@ test('API: Content', t => {
   });
 });
 
-test('API: Content - Descending', t => {
+test.serial('API: Content - Descending', t => {
   const app = {
     get: () => {
       return allTypes;
@@ -428,7 +650,7 @@ test('API: Content - Descending', t => {
   });
 });
 
-test('API: ofType', t => {
+test.serial('API: ofType', t => {
   const item = Math.round(Math.random() * (types.length - 1));
   const type = types[item];
 
@@ -442,7 +664,7 @@ test('API: ofType', t => {
   });
 });
 
-test('API: ofType with Follow', t => {
+test.serial.skip('API: ofType with Follow', t => {
   const item = Math.round(Math.random() * (types.length - 1));
   const type = types[item];
 
@@ -452,7 +674,8 @@ test('API: ofType with Follow', t => {
 
   return api.ofType({
     follow: 'true',
-  }, model).then(results => {
+    depth: 1,
+  }, model, allTypes).then(results => {
     let one = false;
 
     results.items.forEach(itm => {
@@ -478,27 +701,30 @@ test('API: ofType with Follow', t => {
   });
 });
 
-test('API: One', t => {
-  const item = Math.round(Math.random() * (content.length - 1));
-  let expected = cloneDeep(content[item]);
+test.serial.skip('API: One', t => {
+  const query = {
+    depth: 1,
+  };
+  const item = Math.round(Math.random() * (live.length - 1));
+  let expected = cloneDeep(live[item]);
 
   if (expected === undefined) {
-    expected = cloneDeep(content[(content.length - 1)]);
+    expected = cloneDeep(live[(live.length - 1)]);
   }
 
   const model = allTypes.find(typ => {
     return typ.id === expected['type-slug'];
   });
 
-  return api.one({}, expected.id, model.attributes).then(result => {
+  return api.one(query, expected.id, model.attributes, allTypes, database).then(result => {
     t.is(result.id, expected.id, 'IDs the same');
     t.true(result.hasOwnProperty('attributes'));
-    t.is(result.key_slug, expected.slug, 'Key available');
+    t.is(result.key_slug, expected['key-slug'], 'Key available');
     t.true(result.hasOwnProperty('type'), 'Has type info');
   });
 });
 
-test('API: One - Not There', t => {
+test.serial('API: One - Not There', t => {
   return api.one({}, `Test ${Math.round(Math.random() * content.length)}`).then(result => {
     t.deepEqual(result, {}, 'Empty object returned');
   });
@@ -508,7 +734,7 @@ test('API: One - Not There', t => {
 //////////////////////////////
 // AFTER ALL TESTS RUN
 //////////////////////////////
-test.cb.after(t => {
+test.cb.after.always(t => {
   database('live').where('language', lang).del().then(() => {
     t.end();
   })

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -13,7 +13,6 @@ const lang = 'api-test';
 
 const fixtures = utils.generate(generated, lang);
 
-const content = fixtures.content;
 const live = fixtures.live;
 const types = fixtures.types.names;
 const allTypes = fixtures.types.full;
@@ -39,7 +38,7 @@ test.cb.before(t => {
  * Randomly selects a piece of content from source, and it's content-type model
  *
  * @param  {object} source object of content
- * @return {object}  - selected content and its model
+ * @returns {object}  - selected content and its model
  */
 const testables = source => {
   const random = Math.round(Math.random() * (source.length - 1));

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -76,7 +76,6 @@ test.serial.skip('Utils: attributes - depth 0', t => {
     return typ.id === expected['type-slug'];
   });
 
-  // because depth is checked during attributes, depth 1 and 0 are the same for the attributes function
   const query = {
     depth: 0,
   };
@@ -105,7 +104,6 @@ test.serial.skip('Utils: attributes - depth 1', t => {
     return typ.id === expected['type-slug'];
   });
 
-  // because depth is checked during attributes, depth 1 and 0 are the same for the attributes function
   const query = {
     depth: 1,
   };
@@ -181,7 +179,6 @@ test.serial.skip('Utils: attributes - no references', t => {
     return attr !== false;
   });
 
-  // because depth is checked during attributes, depth 1 and 0 are the same for the attributes function
   const query = {
     depth: 0,
   };

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -35,27 +35,11 @@ test.cb.before(t => {
   });
 });
 
-test.cb.after(t => {
-  const items = types.map(type => {
-    return database('live').where('type', type).del().then(() => {
-      return database('schedule').where('type', type).del();
-    });
-  });
-
-  Promise.all(items)
-    .then(() => {
-      t.end();
-    })
-    .catch(e => {
-      t.fail(e);
-    });
-});
-
 //////////////////////////////
 // Utils - attributes
 //////////////////////////////
 test.serial.skip('Utils: attributes - empty query', t => {
-  const random = Math.round(Math.random() * live.length - 1);
+  const random = Math.round(Math.random() * (live.length - 1));
   let expected = live[random];
   if (expected === undefined) {
     expected = cloneDeep(live[(live.length - 1)]);
@@ -76,12 +60,13 @@ test.serial.skip('Utils: attributes - empty query', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e); // eslint-disable-line no-console
+    t.fail(e.stack);
   });
 });
 
 test.serial.skip('Utils: attributes - depth 0', t => {
-  const random = Math.round(Math.random() * live.length - 1);
+  const random = Math.round(Math.random() * (live.length - 1));
   let expected = live[random];
   if (expected === undefined) {
     expected = cloneDeep(live[(live.length - 1)]);
@@ -104,12 +89,13 @@ test.serial.skip('Utils: attributes - depth 0', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e); // eslint-disable-line no-console
+    t.fail(e.stack);
   });
 });
 
 test.serial.skip('Utils: attributes - depth 1', t => {
-  const random = Math.round(Math.random() * live.length - 1);
+  const random = Math.round(Math.random() * (live.length - 1));
   let expected = live[random];
   if (expected === undefined) {
     expected = cloneDeep(live[(live.length - 1)]);
@@ -132,12 +118,13 @@ test.serial.skip('Utils: attributes - depth 1', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e); // eslint-disable-line no-console
+    t.fail(e.stack);
   });
 });
 
 test.serial.skip('Utils: attributes - depth 2', t => {
-  const random = Math.round(Math.random() * live.length - 1);
+  const random = Math.round(Math.random() * (live.length - 1));
   let expected = live[random];
   if (expected === undefined) {
     expected = cloneDeep(live[(live.length - 1)]);
@@ -161,12 +148,13 @@ test.serial.skip('Utils: attributes - depth 2', t => {
     });
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e); // eslint-disable-line no-console
+    t.fail(e.stack);
   });
 });
 
 test.serial.skip('Utils: attributes - no references', t => {
-  const random = Math.round(Math.random() * live.length - 1);
+  const random = Math.round(Math.random() * (live.length - 1));
   let expected = live[random];
   if (expected === undefined) {
     expected = cloneDeep(live[(live.length - 1)]);
@@ -205,7 +193,8 @@ test.serial.skip('Utils: attributes - no references', t => {
     t.is(Object.keys(result).length, 2, 'Should contain two main objects.');
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e); // eslint-disable-line no-console
+    t.fail(e.stack);
   });
 });
 
@@ -641,7 +630,7 @@ test.serial.skip('API: One', t => {
 });
 
 test.serial('API: One - Not There', t => {
-  return api.one({}, `Test ${Math.round(Math.random() * content.length)}`).then(result => {
+  return api.one({}, `Test ${Math.round(Math.random() * (live.length - 1))}`).then(result => {
     t.deepEqual(result, {}, 'Empty object returned');
   });
 });
@@ -656,6 +645,7 @@ test.cb.after.always(t => {
   })
   .catch(e => {
     console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e);
     t.end();
   });
 });

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -206,19 +206,95 @@ test.serial.skip('Utils: Format Results - List', t => {
 
   return formatted.then(result => {
     result.forEach(item => {
-      t.true(item.hasOwnProperty('id'), 'Contains ID');
-      t.true(item.hasOwnProperty('type'), 'Contains Type');
-      t.true(item.hasOwnProperty('type_slug'), 'Contains Type Slug');
-      t.true(item.hasOwnProperty('key'), 'Contains Key');
-      t.true(item.hasOwnProperty('key_slug'), 'Contains Key Slug');
-      t.true(item.hasOwnProperty('meta'), 'Contains Meta');
-      t.false(item.hasOwnProperty('attributes'), 'Does not contain attributes');
-      t.is(item.meta.url, `/api/types/${item.type_slug}/${item.id}`, 'URL points to full content item');
+      utils.attribute(t, item);
     });
   });
 });
 
-test.serial.skip('Utils: Format Results - Attributes', t => {
+test.serial.skip('Utils: Format Results - no query', t => {
+  const item = Math.round(Math.random() * (live.length - 1));
+  let expected = cloneDeep(live[item]);
+
+  if (expected === undefined) {
+    expected = cloneDeep(live[(live.length - 1)]);
+  }
+
+  const model = allTypes.find(typ => {
+    return typ.id === expected['type-slug'];
+  });
+
+  const formatted = apiUtils.format([expected], model.attributes, allTypes);
+
+  return formatted.then(result => {
+    result.forEach(itm => {
+      utils.attribute(t, itm);
+    });
+  });
+});
+
+test.serial.skip('Utils: Format Results - query depth zero', t => {
+  const query = {
+    depth: 0,
+  };
+  const item = Math.round(Math.random() * (live.length - 1));
+  let expected = cloneDeep(live[item]);
+
+  if (expected === undefined) {
+    expected = cloneDeep(live[(live.length - 1)]);
+  }
+
+  const model = allTypes.find(typ => {
+    return typ.id === expected['type-slug'];
+  });
+
+  const formatted = apiUtils.format([expected], model.attributes, allTypes, query);
+
+  return formatted.then(result => {
+    result.forEach(itm => {
+      utils.attribute(t, itm);
+    });
+  });
+});
+
+test.serial.skip('Utils: Format Results - query depth one', t => {
+  const query = {
+    depth: 1,
+  };
+  const item = Math.round(Math.random() * (live.length - 1));
+  let expected = cloneDeep(live[item]);
+
+  if (expected === undefined) {
+    expected = cloneDeep(live[(live.length - 1)]);
+  }
+
+  const model = allTypes.find(typ => {
+    return typ.id === expected['type-slug'];
+  });
+
+  const formatted = apiUtils.format([expected], model.attributes, allTypes, query);
+
+  return formatted.then(result => {
+    result.forEach(itm => {
+      utils.attribute(t, itm);
+      t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
+
+      Object.keys(itm.attributes).forEach(attr => {
+        if (attr.split('-').indexOf('referencer') > -1) {
+          if (itm.attributes[attr].hasOwnProperty('id')) {
+            utils.attribute(t, itm.attributes[attr]);
+          }
+          else if (!Array.isArray(itm.attributes[attr])) {
+            Object.keys(itm.attributes[attr]).forEach(atr => {
+              utils.attribute(t, itm.attributes[attr][atr]);
+            });
+          }
+        }
+      });
+    });
+  });
+});
+
+test.serial.skip('Utils: Format Results - query depth two', t => {
   const query = {
     depth: 2,
   };
@@ -237,13 +313,33 @@ test.serial.skip('Utils: Format Results - Attributes', t => {
 
   return formatted.then(result => {
     result.forEach(itm => {
-      t.true(itm.hasOwnProperty('id'), 'Contains ID');
-      t.true(itm.hasOwnProperty('type'), 'Contains Type');
-      t.true(itm.hasOwnProperty('type_slug'), 'Contains Type Slug');
-      t.true(itm.hasOwnProperty('key'), 'Contains Key');
-      t.true(itm.hasOwnProperty('key_slug'), 'Contains Key Slug');
-      t.false(itm.hasOwnProperty('meta'), 'Does not contain Meta');
+      utils.attribute(t, itm);
       t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
+
+      Object.keys(itm.attributes).forEach(attr => {
+        if (attr.split('-').indexOf('referencer') > -1) {
+          if (itm.attributes[attr].hasOwnProperty('id')) {
+            utils.attribute(t, itm.attributes[attr]);
+            Object.keys(itm.attributes[attr]).forEach(atr => {
+              if (atr.split('-').indexOf('referencer') > -1) {
+                if (itm.attributes[attr][atr].hasOwnProperty('id')) {
+                  utils.attribute(t, itm.attributes[attr][atr]);
+                }
+                else if (!Array.isArray(itm.attributes[attr][atr])) {
+                  Object.keys(itm.attributes[attr][atr]).forEach(ar => {
+                    utils.attribute(t, itm.attributes[attr][atr][ar]);
+                  });
+                }
+              }
+            });
+          }
+          else if (!Array.isArray(itm.attributes[attr])) {
+            Object.keys(itm.attributes[attr]).forEach(atr => {
+              utils.attribute(t, itm.attributes[attr][atr]);
+            });
+          }
+        }
+      });
     });
   });
 });
@@ -501,14 +597,7 @@ test.serial.skip('API: All with Follow', t => {
       // Ignore empty object
       if (Object.keys(item).length !== 0) {
         one = true;
-        t.true(item.hasOwnProperty('id'), 'Each item has an ID');
-        t.true(item.hasOwnProperty('type'), 'Each item has a type');
-        t.true(item.type.hasOwnProperty('name'), 'Each item type has an name');
-        t.true(item.type.hasOwnProperty('slug'), 'Each item type has an slug');
-        t.true(item.type.hasOwnProperty('url'), 'Each item type has an url');
-        t.true(item.hasOwnProperty('key'), 'Each item has a key');
-        t.true(item.hasOwnProperty('key_slug'), 'Each item has a key_slug');
-        t.true(item.hasOwnProperty('attributes'), 'Each item has attributes');
+        utils.attribute(t, item);
       }
     });
     t.true(results.hasOwnProperty('items'), 'Has Items');
@@ -587,14 +676,7 @@ test.serial.skip('API: ofType with Follow', t => {
       // Ignore empty object
       if (Object.keys(itm).length !== 0) {
         one = true;
-        t.true(itm.hasOwnProperty('id'), 'Each item has an ID');
-        t.true(itm.hasOwnProperty('type'), 'Each item has a type');
-        t.true(itm.type.hasOwnProperty('name'), 'Each item type has an name');
-        t.true(itm.type.hasOwnProperty('slug'), 'Each item type has an slug');
-        t.true(itm.type.hasOwnProperty('url'), 'Each item type has an url');
-        t.true(itm.hasOwnProperty('key'), 'Each item has a key');
-        t.true(itm.hasOwnProperty('key_slug'), 'Each item has a key_slug');
-        t.true(itm.hasOwnProperty('attributes'), 'Each item has attributes');
+        utils.attribute(t, itm);
       }
     });
     t.true(results.hasOwnProperty('items'), 'Has Items');

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -34,34 +34,11 @@ test.cb.before(t => {
   });
 });
 
-/**
- * Randomly selects a piece of content from source, and it's content-type model
- *
- * @param  {object} source object of content
- * @returns {object}  - selected content and its model
- */
-const testables = source => {
-  const random = Math.round(Math.random() * (source.length - 1));
-  let expected = source[random];
-  if (expected === undefined) {
-    expected = cloneDeep(source[(source.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
-
-  return {
-    expected,
-    model,
-  };
-};
-
 //////////////////////////////
 // Utils - attributes
 //////////////////////////////
 test.serial.skip('Utils: attributes - empty query', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
 
   const query = {};
 
@@ -81,7 +58,7 @@ test.serial.skip('Utils: attributes - empty query', t => {
 });
 
 test.serial.skip('Utils: attributes - depth 0', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
 
   const query = {
     depth: 0,
@@ -102,7 +79,7 @@ test.serial.skip('Utils: attributes - depth 0', t => {
 });
 
 test.serial.skip('Utils: attributes - depth 1', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
 
   const query = {
     depth: 1,
@@ -123,7 +100,7 @@ test.serial.skip('Utils: attributes - depth 1', t => {
 });
 
 test.serial.skip('Utils: attributes - depth 2', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
 
   const query = {
     depth: 2,
@@ -146,7 +123,7 @@ test.serial.skip('Utils: attributes - depth 2', t => {
 });
 
 test.serial.skip('Utils: attributes - no references', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
 
   Object.keys(testable.expected.attributes).forEach(attr => {
     if (attr.split('-').indexOf('referencer') > -1) {
@@ -196,7 +173,7 @@ test.serial.skip('Utils: Format Results - List', t => {
 });
 
 test.serial.skip('Utils: Format Results - no query', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
 
   const formatted = apiUtils.format([testable.expected], testable.model.attributes, allTypes);
 
@@ -208,7 +185,7 @@ test.serial.skip('Utils: Format Results - no query', t => {
 });
 
 test.serial.skip('Utils: Format Results - query depth zero', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
   const query = {
     depth: 0,
   };
@@ -223,7 +200,7 @@ test.serial.skip('Utils: Format Results - query depth zero', t => {
 });
 
 test.serial.skip('Utils: Format Results - query depth one', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
   const query = {
     depth: 1,
   };
@@ -235,24 +212,14 @@ test.serial.skip('Utils: Format Results - query depth one', t => {
       utils.formatted(t, itm);
       t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
 
-      Object.keys(itm.attributes).forEach(attr => {
-        if (attr.split('-').indexOf('referencer') > -1) {
-          if (itm.attributes[attr].hasOwnProperty('id')) {
-            utils.formatted(t, itm.attributes[attr]);
-          }
-          else if (!Array.isArray(itm.attributes[attr])) {
-            Object.keys(itm.attributes[attr]).forEach(atr => {
-              utils.formatted(t, itm.attributes[attr][atr]);
-            });
-          }
-        }
-      });
+      utils.depths(t, itm.attributes, query.depth);
+
     });
   });
 });
 
 test.serial.skip('Utils: Format Results - query depth two', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
   const query = {
     depth: 2,
   };
@@ -264,30 +231,7 @@ test.serial.skip('Utils: Format Results - query depth two', t => {
       utils.formatted(t, itm);
       t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
 
-      Object.keys(itm.attributes).forEach(attr => {
-        if (attr.split('-').indexOf('referencer') > -1) {
-          if (itm.attributes[attr].hasOwnProperty('id')) {
-            utils.formatted(t, itm.attributes[attr]);
-            Object.keys(itm.attributes[attr]).forEach(atr => {
-              if (atr.split('-').indexOf('referencer') > -1) {
-                if (itm.attributes[attr][atr].hasOwnProperty('id')) {
-                  utils.formatted(t, itm.attributes[attr][atr]);
-                }
-                else if (!Array.isArray(itm.attributes[attr][atr])) {
-                  Object.keys(itm.attributes[attr][atr]).forEach(ar => {
-                    utils.formatted(t, itm.attributes[attr][atr][ar]);
-                  });
-                }
-              }
-            });
-          }
-          else if (!Array.isArray(itm.attributes[attr])) {
-            Object.keys(itm.attributes[attr]).forEach(atr => {
-              utils.formatted(t, itm.attributes[attr][atr]);
-            });
-          }
-        }
-      });
+      utils.depths(t, itm.attributes, query.depth);
     });
   });
 });
@@ -526,20 +470,33 @@ test.serial('APIs: Types', t => {
   t.true(isEqual(apiTypes.keys, keys), 'Keys are as expected');
 });
 
+//////////////////////////////
+// APIs - all
+//////////////////////////////
 test.serial('API: All', t => {
   return api.all({}, allTypes).then(results => {
     t.true(results.hasOwnProperty('items'), 'Has Items');
     t.true(results.hasOwnProperty('pages'), 'Has Pagination');
     t.true(results.items.length >= generated, 'Has at least all items in it');
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        utils.formatted(t, item);
+      }
+    });
   });
 });
 
-test.serial.skip('API: All with Follow', t => {
+test.serial('API: All with depth 0', t => {
   return api.all({
-    follow: 'true',
-    depth: 1,
+    depth: 0,
   }, allTypes).then(results => {
     let one = false;
+
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+    t.true(results.items.length >= generated, 'Has at least all items in it');
 
     results.items.forEach(item => {
       // Ignore empty object
@@ -548,9 +505,165 @@ test.serial.skip('API: All with Follow', t => {
         utils.formatted(t, item);
       }
     });
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: All with depth 1', t => {
+  return api.all({
+    depth: 1,
+  }, allTypes).then(results => {
+    let one = false;
+
     t.true(results.hasOwnProperty('items'), 'Has Items');
     t.true(results.hasOwnProperty('pages'), 'Has Pagination');
     t.true(results.items.length >= generated, 'Has at least all items in it');
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 1);
+      }
+    });
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: All with depth 2', t => {
+  return api.all({
+    depth: 2,
+  }, allTypes).then(results => {
+    let one = false;
+
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+    t.true(results.items.length >= generated, 'Has at least all items in it');
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 2);
+      }
+    });
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: All with Follow', t => {
+  return api.all({
+    follow: 'true',
+  }, allTypes).then(results => {
+    let one = false;
+
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+    t.true(results.items.length >= generated, 'Has at least all items in it');
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+      }
+    });
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: All with Follow with depth zero', t => {
+  return api.all({
+    follow: 'true',
+    depth: 0,
+  }, allTypes).then(results => {
+    let one = false;
+
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+    t.true(results.items.length >= generated, 'Has at least all items in it');
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+      }
+    });
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: All with Follow with depth one', t => {
+  return api.all({
+    follow: 'true',
+    depth: 1,
+  }, allTypes).then(results => {
+    let one = false;
+
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+    t.true(results.items.length >= generated, 'Has at least all items in it');
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 1);
+      }
+    });
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: All with Follow with depth two', t => {
+  return api.all({
+    follow: 'true',
+    depth: 2,
+  }, allTypes).then(results => {
+    let one = false;
+
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+    t.true(results.items.length >= generated, 'Has at least all items in it');
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 2);
+      }
+    });
 
     if (results.items.length > 0) {
       t.true(one, 'At least one item returned in items');
@@ -593,31 +706,20 @@ test.serial('API: Content - Descending', t => {
 });
 
 test.serial('API: ofType', t => {
-  const item = Math.round(Math.random() * (types.length - 1));
-  const type = types[item];
+  const testable = utils.testables(live, allTypes);
 
-  const model = allTypes.find(typ => {
-    return typ.id === slugify(type);
-  });
-
-  return api.ofType({}, model).then(formatted => {
+  return api.ofType({}, testable.model, allTypes).then(formatted => {
     t.true(formatted.hasOwnProperty('items'), 'Has Items');
     t.true(formatted.hasOwnProperty('pages'), 'Has Pagination');
   });
 });
 
-test.serial.skip('API: ofType with Follow', t => {
-  const item = Math.round(Math.random() * (types.length - 1));
-  const type = types[item];
-
-  const model = allTypes.find(typ => {
-    return typ.id === slugify(type);
-  });
+test.serial('API: ofType depth zero', t => {
+  const testable = utils.testables(live, allTypes);
 
   return api.ofType({
-    follow: 'true',
-    depth: 1,
-  }, model, allTypes).then(results => {
+    depth: 0,
+  }, testable.model, allTypes).then(results => {
     let one = false;
 
     results.items.forEach(itm => {
@@ -636,18 +738,214 @@ test.serial.skip('API: ofType with Follow', t => {
   });
 });
 
+test.serial.skip('API: ofType depth one', t => {
+  const testable = utils.testables(live, allTypes);
+
+  return api.ofType({
+    depth: 1,
+  }, testable.model, allTypes).then(results => {
+    let one = false;
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 1);
+      }
+    });
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: ofType depth two', t => {
+  const testable = utils.testables(live, allTypes);
+
+  return api.ofType({
+    depth: 2,
+  }, testable.model, allTypes).then(results => {
+    let one = false;
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 2);
+      }
+    });
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: ofType with Follow', t => {
+  const testable = utils.testables(live, allTypes);
+
+  return api.ofType({
+    follow: 'true',
+  }, testable.model, allTypes).then(results => {
+    let one = false;
+
+    results.items.forEach(itm => {
+      // Ignore empty object
+      if (Object.keys(itm).length !== 0) {
+        one = true;
+        utils.formatted(t, itm);
+      }
+    });
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: ofType with Follow with depth zero', t => {
+  const testable = utils.testables(live, allTypes);
+
+  return api.ofType({
+    follow: 'true',
+    depth: 0,
+  }, testable.model, allTypes).then(results => {
+    let one = false;
+
+    results.items.forEach(itm => {
+      // Ignore empty object
+      if (Object.keys(itm).length !== 0) {
+        one = true;
+        utils.formatted(t, itm);
+      }
+    });
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: ofType with Follow with depth one', t => {
+  const testable = utils.testables(live, allTypes);
+
+  return api.ofType({
+    follow: 'true',
+    depth: 1,
+  }, testable.model, allTypes).then(results => {
+    let one = false;
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 1);
+      }
+    });
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
+
+test.serial.skip('API: ofType with Follow with depth two', t => {
+  const testable = utils.testables(live, allTypes);
+
+  return api.ofType({
+    follow: 'true',
+    depth: 2,
+  }, testable.model, allTypes).then(results => {
+    let one = false;
+
+    results.items.forEach(item => {
+      // Ignore empty object
+      if (Object.keys(item).length !== 0) {
+        one = true;
+        utils.formatted(t, item);
+        t.true(item.hasOwnProperty('attributes'), 'Contains attributes');
+
+        utils.depths(t, item.attributes, 2);
+      }
+    });
+    t.true(results.hasOwnProperty('items'), 'Has Items');
+    t.true(results.hasOwnProperty('pages'), 'Has Pagination');
+
+    if (results.items.length > 0) {
+      t.true(one, 'At least one item returned in items');
+    }
+  });
+});
 
 test.serial.skip('API: One', t => {
-  const testable = testables(live);
+  const testable = utils.testables(live, allTypes);
+  const query = {};
+
+  return api.one(query, testable.expected.id, testable.model.attributes, allTypes, database).then(result => {
+    t.is(result.id, testable.expected.id, 'IDs the same');
+    utils.formatted(t, result);
+    t.false(result.hasOwnProperty('attributes'));
+  });
+});
+
+test.serial.skip('API: One - depth zero', t => {
+  const testable = utils.testables(live, allTypes);
+  const query = {
+    depth: 0,
+  };
+
+  return api.one(query, testable.expected.id, testable.model.attributes, allTypes, database).then(result => {
+    t.is(result.id, testable.expected.id, 'IDs the same');
+    utils.formatted(t, result);
+    t.false(result.hasOwnProperty('attributes'));
+  });
+});
+
+test.serial.skip('API: One - depth one', t => {
+  const testable = utils.testables(live, allTypes);
   const query = {
     depth: 1,
   };
 
   return api.one(query, testable.expected.id, testable.model.attributes, allTypes, database).then(result => {
     t.is(result.id, testable.expected.id, 'IDs the same');
+    utils.formatted(t, result);
     t.true(result.hasOwnProperty('attributes'));
-    t.is(result.key_slug, testable.expected['key-slug'], 'Key available');
-    t.true(result.hasOwnProperty('type'), 'Has type info');
+    utils.depths(t, result.attributes, 1);
+  });
+});
+
+test.serial.skip('API: One - depth two', t => {
+  const testable = utils.testables(live, allTypes);
+  const query = {
+    depth: 2,
+  };
+
+  return api.one(query, testable.expected.id, testable.model.attributes, allTypes, database).then(result => {
+    t.is(result.id, testable.expected.id, 'IDs the same');
+    utils.formatted(t, result);
+    t.true(result.hasOwnProperty('attributes'));
+    utils.depths(t, result.attributes, 2);
   });
 });
 

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -51,88 +51,6 @@ test.cb.after(t => {
     });
 });
 
-/**
- * Tests attributes with references
- * @param  {object} t - ava testing
- * @param  {object|array} attrs object containing attributes to test
- */
-const referencerTests = (t, attrs) => {
-  if (typeof attrs !== 'object' || attrs === undefined) {
-    return;
-  }
-
-  if (attrs.hasOwnProperty('attributes')) {
-    referencerTests(t, attrs.attributes);
-
-    return;
-  }
-
-  if (Array.isArray(attrs)) {
-    attrs.forEach(attr => {
-      Object.keys(attr).forEach(atr => {
-        if (attr[atr].hasOwnProperty('attributes')) {
-          referencerTests(t, attr[atr].attributes);
-
-          return;
-        }
-        else if (attr[atr].hasOwnProperty('id')) {
-          t.true(attr[atr].hasOwnProperty('meta'), 'attribute in array contains meta');
-
-          return;
-        }
-      });
-    });
-  }
-
-  // check if this object is an attribute object
-  if (Object.keys(attrs).indexOf('id') !== -1) {
-    t.true(attrs.poo.hasOwnProperty('meta'), 'attribute in array contains meta');
-
-    return;
-  }
-
-  Object.keys(attrs).forEach(attr => {
-    if (attr.split('-').indexOf('referencer') > -1) {
-      const item = attrs[attr];
-
-      // if item has attributes
-      if (item.hasOwnProperty('attributes')) {
-        referencerTests(t, item.attributes);
-
-        return;
-      }
-
-      // if it's an array, recurseit!
-      if (Array.isArray(item)) {
-        referencerTests(t, item);
-
-        return;
-      }
-
-      if (typeof item === 'object' && typeof item[Object.keys(item)[0]] === 'object' && item[Object.keys(item)[0]].hasOwnProperty('attributes')) {
-        referencerTests(t, item.attributes);
-
-        return;
-      }
-
-      if (Object.keys(item).indexOf('id') === -1 && Object.keys(item).length >= 1) {
-        Object.keys(item).forEach(itm => {
-          t.true(item[itm].hasOwnProperty('meta'), 'attribute in array contains meta');
-
-          return;
-        });
-      }
-
-      // non-repeatable; single input
-      else {
-        t.true(item.hasOwnProperty('meta'), 'attribute in array contains meta');
-
-        return;
-      }
-    }
-  });
-};
-
 //////////////////////////////
 // Utils - attributes
 //////////////////////////////
@@ -155,7 +73,7 @@ test.serial.skip('Utils: attributes - empty query', t => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
     t.is(Object.keys(result).length, 6, 'Should contain six main objects.');
 
-    referencerTests(t, result);
+    utils.referencer(t, result);
   })
   .catch(e => {
     console.log(e); // eslint-disable-line no-console
@@ -183,7 +101,7 @@ test.serial.skip('Utils: attributes - depth 0', t => {
   return attributes.then(result => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
 
-    referencerTests(t, result);
+    utils.referencer(t, result);
   })
   .catch(e => {
     console.log(e); // eslint-disable-line no-console
@@ -211,7 +129,7 @@ test.serial.skip('Utils: attributes - depth 1', t => {
   return attributes.then(result => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
 
-    referencerTests(t, result);
+    utils.referencer(t, result);
   })
   .catch(e => {
     console.log(e); // eslint-disable-line no-console
@@ -239,7 +157,7 @@ test.serial.skip('Utils: attributes - depth 2', t => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
 
     Object.keys(result).forEach(key => {
-      referencerTests(t, result[key]);
+      utils.referencer(t, result[key]);
     });
   })
   .catch(e => {

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -74,7 +74,9 @@ test.serial.skip('Utils: attributes - empty query', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e);
+    t.end();
   });
 });
 
@@ -93,7 +95,9 @@ test.serial.skip('Utils: attributes - depth 0', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e);
+    t.end();
   });
 });
 
@@ -112,7 +116,9 @@ test.serial.skip('Utils: attributes - depth 1', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e);
+    t.end();
   });
 });
 
@@ -133,7 +139,9 @@ test.serial.skip('Utils: attributes - depth 2', t => {
     });
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e);
+    t.end();
   });
 });
 
@@ -168,7 +176,9 @@ test.serial.skip('Utils: attributes - no references', t => {
     t.is(Object.keys(result).length, 2, 'Should contain two main objects.');
   })
   .catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e);
+    t.end();
   });
 });
 

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -35,23 +35,38 @@ test.cb.before(t => {
   });
 });
 
-//////////////////////////////
-// Utils - attributes
-//////////////////////////////
-test.serial.skip('Utils: attributes - empty query', t => {
-  const random = Math.round(Math.random() * (live.length - 1));
-  let expected = live[random];
+/**
+ * Randomly selects a piece of content from source, and it's content-type model
+ *
+ * @param  {object} source object of content
+ * @return {object}  - selected content and its model
+ */
+const testables = source => {
+  const random = Math.round(Math.random() * (source.length - 1));
+  let expected = source[random];
   if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
+    expected = cloneDeep(source[(source.length - 1)]);
   }
 
   const model = allTypes.find(typ => {
     return typ.id === expected['type-slug'];
   });
 
+  return {
+    expected,
+    model,
+  };
+};
+
+//////////////////////////////
+// Utils - attributes
+//////////////////////////////
+test.serial.skip('Utils: attributes - empty query', t => {
+  const testable = testables(live);
+
   const query = {};
 
-  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+  const attributes = apiUtils.attributes(testable.expected.attributes, testable.model.attributes, allTypes, query);
 
   return attributes.then(result => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
@@ -60,27 +75,18 @@ test.serial.skip('Utils: attributes - empty query', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.error(e); // eslint-disable-line no-console
-    t.fail(e.stack);
+    console.log(e); // eslint-disable-line no-console
   });
 });
 
 test.serial.skip('Utils: attributes - depth 0', t => {
-  const random = Math.round(Math.random() * (live.length - 1));
-  let expected = live[random];
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
+  const testable = testables(live);
 
   const query = {
     depth: 0,
   };
 
-  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+  const attributes = apiUtils.attributes(testable.expected.attributes, testable.model.attributes, allTypes, query);
 
   return attributes.then(result => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
@@ -88,27 +94,18 @@ test.serial.skip('Utils: attributes - depth 0', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.error(e); // eslint-disable-line no-console
-    t.fail(e.stack);
+    console.log(e); // eslint-disable-line no-console
   });
 });
 
 test.serial.skip('Utils: attributes - depth 1', t => {
-  const random = Math.round(Math.random() * (live.length - 1));
-  let expected = live[random];
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
+  const testable = testables(live);
 
   const query = {
     depth: 1,
   };
 
-  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+  const attributes = apiUtils.attributes(testable.expected.attributes, testable.model.attributes, allTypes, query);
 
   return attributes.then(result => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
@@ -116,27 +113,18 @@ test.serial.skip('Utils: attributes - depth 1', t => {
     utils.referencer(t, result);
   })
   .catch(e => {
-    console.error(e); // eslint-disable-line no-console
-    t.fail(e.stack);
+    console.log(e); // eslint-disable-line no-console
   });
 });
 
 test.serial.skip('Utils: attributes - depth 2', t => {
-  const random = Math.round(Math.random() * (live.length - 1));
-  let expected = live[random];
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
+  const testable = testables(live);
 
   const query = {
     depth: 2,
   };
 
-  const attributes = apiUtils.attributes(expected.attributes, model.attributes, allTypes, query);
+  const attributes = apiUtils.attributes(testable.expected.attributes, testable.model.attributes, allTypes, query);
 
   return attributes.then(result => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
@@ -146,29 +134,20 @@ test.serial.skip('Utils: attributes - depth 2', t => {
     });
   })
   .catch(e => {
-    console.error(e); // eslint-disable-line no-console
-    t.fail(e.stack);
+    console.log(e); // eslint-disable-line no-console
   });
 });
 
 test.serial.skip('Utils: attributes - no references', t => {
-  const random = Math.round(Math.random() * (live.length - 1));
-  let expected = live[random];
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
+  const testable = testables(live);
 
-  Object.keys(expected.attributes).forEach(attr => {
+  Object.keys(testable.expected.attributes).forEach(attr => {
     if (attr.split('-').indexOf('referencer') > -1) {
-      delete expected.attributes[attr];
+      delete testable.expected.attributes[attr];
     }
   });
 
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
-
-  let modelattrs = cloneDeep(model.attributes);
+  let modelattrs = cloneDeep(testable.model.attributes);
   modelattrs = modelattrs.map(attr => {
     if (attr.id.split('-').indexOf('referencer') < 0) {
       return attr;
@@ -183,15 +162,14 @@ test.serial.skip('Utils: attributes - no references', t => {
     depth: 0,
   };
 
-  const attributes = apiUtils.attributes(expected.attributes, modelattrs, allTypes, query);
+  const attributes = apiUtils.attributes(testable.expected.attributes, modelattrs, allTypes, query);
 
   return attributes.then(result => {
     t.is(typeof result, 'object', 'Should contain result, an object.');
     t.is(Object.keys(result).length, 2, 'Should contain two main objects.');
   })
   .catch(e => {
-    console.error(e); // eslint-disable-line no-console
-    t.fail(e.stack);
+    console.log(e); // eslint-disable-line no-console
   });
 });
 
@@ -209,18 +187,9 @@ test.serial.skip('Utils: Format Results - List', t => {
 });
 
 test.serial.skip('Utils: Format Results - no query', t => {
-  const item = Math.round(Math.random() * (live.length - 1));
-  let expected = cloneDeep(live[item]);
+  const testable = testables(live);
 
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
-
-  const formatted = apiUtils.format([expected], model.attributes, allTypes);
+  const formatted = apiUtils.format([testable.expected], testable.model.attributes, allTypes);
 
   return formatted.then(result => {
     result.forEach(itm => {
@@ -230,21 +199,12 @@ test.serial.skip('Utils: Format Results - no query', t => {
 });
 
 test.serial.skip('Utils: Format Results - query depth zero', t => {
+  const testable = testables(live);
   const query = {
     depth: 0,
   };
-  const item = Math.round(Math.random() * (live.length - 1));
-  let expected = cloneDeep(live[item]);
 
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
-
-  const formatted = apiUtils.format([expected], model.attributes, allTypes, query);
+  const formatted = apiUtils.format([testable.expected], testable.model.attributes, allTypes, query);
 
   return formatted.then(result => {
     result.forEach(itm => {
@@ -254,21 +214,12 @@ test.serial.skip('Utils: Format Results - query depth zero', t => {
 });
 
 test.serial.skip('Utils: Format Results - query depth one', t => {
+  const testable = testables(live);
   const query = {
     depth: 1,
   };
-  const item = Math.round(Math.random() * (live.length - 1));
-  let expected = cloneDeep(live[item]);
 
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
-
-  const formatted = apiUtils.format([expected], model.attributes, allTypes, query);
+  const formatted = apiUtils.format([testable.expected], testable.model.attributes, allTypes, query);
 
   return formatted.then(result => {
     result.forEach(itm => {
@@ -292,21 +243,12 @@ test.serial.skip('Utils: Format Results - query depth one', t => {
 });
 
 test.serial.skip('Utils: Format Results - query depth two', t => {
+  const testable = testables(live);
   const query = {
     depth: 2,
   };
-  const item = Math.round(Math.random() * (live.length - 1));
-  let expected = cloneDeep(live[item]);
 
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
-
-  const formatted = apiUtils.format([expected], model.attributes, allTypes, query);
+  const formatted = apiUtils.format([testable.expected], testable.model.attributes, allTypes, query);
 
   return formatted.then(result => {
     result.forEach(itm => {
@@ -685,22 +627,14 @@ test.serial.skip('API: ofType with Follow', t => {
   });
 });
 
+
 test.serial.skip('API: One', t => {
+  const testable = testables(live);
   const query = {
     depth: 1,
   };
-  const item = Math.round(Math.random() * (live.length - 1));
-  let expected = cloneDeep(live[item]);
 
-  if (expected === undefined) {
-    expected = cloneDeep(live[(live.length - 1)]);
-  }
-
-  const model = allTypes.find(typ => {
-    return typ.id === expected['type-slug'];
-  });
-
-  return api.one(query, expected.id, model.attributes, allTypes, database).then(result => {
+  return api.one(query, testable.expected.id, testable.model.attributes, allTypes, database).then(result => {
     t.is(result.id, expected.id, 'IDs the same');
     t.true(result.hasOwnProperty('attributes'));
     t.is(result.key_slug, expected['key-slug'], 'Key available');

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -635,9 +635,9 @@ test.serial.skip('API: One', t => {
   };
 
   return api.one(query, testable.expected.id, testable.model.attributes, allTypes, database).then(result => {
-    t.is(result.id, expected.id, 'IDs the same');
+    t.is(result.id, testable.expected.id, 'IDs the same');
     t.true(result.hasOwnProperty('attributes'));
-    t.is(result.key_slug, expected['key-slug'], 'Key available');
+    t.is(result.key_slug, testable.expected['key-slug'], 'Key available');
     t.true(result.hasOwnProperty('type'), 'Has type info');
   });
 });

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import slugify from 'underscore.string/slugify';
 import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -14,7 +13,6 @@ const lang = 'api-test';
 const fixtures = utils.generate(generated, lang);
 
 const live = fixtures.live;
-const types = fixtures.types.names;
 const allTypes = fixtures.types.full;
 
 test.cb.before(t => {
@@ -213,7 +211,6 @@ test.serial.skip('Utils: Format Results - query depth one', t => {
       t.true(itm.hasOwnProperty('attributes'), 'Contains attributes');
 
       utils.depths(t, itm.attributes, query.depth);
-
     });
   });
 });

--- a/tests/apis.js
+++ b/tests/apis.js
@@ -55,8 +55,6 @@ test.cb.after(t => {
  * Tests attributes with references
  * @param  {object} t - ava testing
  * @param  {object|array} attrs object containing attributes to test
- *
- * @return {null} returns nothing
  */
 const referencerTests = (t, attrs) => {
   if (typeof attrs !== 'object' || attrs === undefined) {

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -210,158 +210,111 @@ const values = ctype => {
 };
 
 /**
- * Tests attributes with references
- * @param  {object} t - ava testing
- * @param  {object|array} attrs object containing attributes to test
+ * Tests a piece of content formatted for the api
  *
- * @returns {object|function|boolean} various returns
- */
-const referencer = (t, attrs) => {
-  if (typeof attrs !== 'object' || attrs === undefined) {
-    return;
-  }
-
-  // an individual piece of content, so we need to test just the attributes
-  if (attrs.hasOwnProperty('attributes')) {
-    // eslint will not allow a return here
-    return referencer(t, attrs.attributes); // eslint-disable-line consistent-return
-  }
-
-  // an array of attributes, this set of attributes is a repeatable
-  if (Array.isArray(attrs)) {
-    attrs.forEach(attr => {
-      Object.keys(attr).forEach(atr => {
-        // an individual piece of content, so we need to test just the attributes
-        // at this point, we've found a piece of content _inside_ a piece of content's attributes
-        if (attr[atr].hasOwnProperty('attributes')) {
-          return referencer(t, attr[atr].attributes);
-        }
-
-        // we've reached our depth, test `meta` exists
-        else if (attr[atr].hasOwnProperty('id')) {
-          t.true(attr[atr].hasOwnProperty('meta'), 'attribute in array contains meta');
-          t.true(attr[atr].meta.hasOwnProperty('url'), 'attribute in array contains meta url');
-
-          return true;
-        }
-
-        return true;
-      });
-    });
-  }
-
-  // now we go through each attribute
-  Object.keys(attrs).forEach(attr => {
-    // only testing referencer attributes
-    if (attr.split('-').indexOf('referencer') > -1) {
-      const item = attrs[attr];
-
-      // if attributes exists, we're still digging down in our depth, recurseit!
-      if (item.hasOwnProperty('attributes')) {
-        return referencer(t, item.attributes);
-      }
-
-      // if it's an array, we're in a repeatable - recurseit!
-      if (Array.isArray(item)) {
-        return referencer(t, item);
-      }
-
-      // non-repeatable attribute with multiple inputs
-      if (typeof item === 'object' && typeof item[Object.keys(item)[0]] === 'object') {
-        // if it has attributes, we're not at depth so....uuuuuuhhhhhhhaaaAAAAHHHH recursit!
-        if (item[Object.keys(item)[0]].hasOwnProperty('attributes')) {
-          Object.keys(item).forEach(itm => {
-            return referencer(t, item[itm].attributes);
-          });
-
-          return true;
-        }
-
-        // no attributes - it should have a meta then
-        Object.keys(item).forEach(itm => {
-          t.true(item[itm].hasOwnProperty('meta'), 'attribute in array contains meta');
-          t.true(item[itm].meta.hasOwnProperty('url'), 'attribute in array contains meta url');
-
-          return true;
-        });
-      }
-
-      // non-repeatable; single input
-      else {
-        t.true(item.hasOwnProperty('meta'), 'attribute in array contains meta');
-        t.true(item.meta.hasOwnProperty('url'), 'attribute in array contains meta url');
-      }
-    }
-
-    return true;
-  });
-};
-
-/**
- * Tests for a formatted attribute
  * @param  {object} t - ava testing
- * @param  {object} attr object containing attributes to test
- *
- * @returns {boolean} returns true
+ * @param  {object} content - the piece of content
+ * @param {object} query - request query
  */
-const formatted = (t, attr) => {
+const formatted = (t, content, query) => {
+  const qry = cloneDeep(query) || {};
   let typeslug;
 
-  t.true(attr.hasOwnProperty('id'), 'Contains ID');
-  t.true(attr.hasOwnProperty('type'), 'Contains Type');
+  t.true(content.hasOwnProperty('id'), 'Contains ID');
+  t.true(content.hasOwnProperty('type'), 'Contains Type');
 
-  if (typeof attr.type === 'object') {
-    t.true(attr.type.hasOwnProperty('name'), 'Contains Type Name');
-    t.true(attr.type.hasOwnProperty('slug'), 'Contains Type Slug');
-    t.true(attr.type.hasOwnProperty('url'), 'Contains Type url');
-    typeslug = attr.type.slug;
+  if (typeof content.type === 'object') {
+    t.true(content.type.hasOwnProperty('name'), 'Contains Type Name');
+    t.true(content.type.hasOwnProperty('slug'), 'Contains Type Slug');
+    t.true(content.type.hasOwnProperty('url'), 'Contains Type url');
+    typeslug = content.type.slug;
   }
   else {
-    t.true(attr.hasOwnProperty('type_slug'), 'Contains Type Slug');
-    typeslug = attr.type_slug;
+    t.true(content.hasOwnProperty('type_slug'), 'Contains Type Slug');
+    typeslug = content.type_slug;
   }
 
-  t.true(attr.hasOwnProperty('key'), 'Contains Key');
-  t.true(attr.hasOwnProperty('key_slug'), 'Contains Key Slug');
+  t.true(content.hasOwnProperty('key'), 'Contains Key');
+  t.true(content.hasOwnProperty('key_slug'), 'Contains Key Slug');
 
-  if (!attr.hasOwnProperty('meta')) {
-    t.true(attr.hasOwnProperty('attributes'), 'Contains attributes');
+  // if follow, then should have attributes
+  if (qry.follow) {
+    t.true(content.hasOwnProperty('attributes'), 'Contains attributes');
 
-    return referencer(t, attr.attributes);
+    // if we still have depth, keep digging down
+    if (qry.depth > 0) {
+      // circular eslint problem
+      depths(t, content.attributes, qry); // eslint-disable-line no-use-before-define
+    }
+  }
+  else {
+    t.true(content.hasOwnProperty('meta'), 'Contains Meta');
+    t.false(content.hasOwnProperty('attributes'), 'Does not contain attributes');
+    t.is(content.meta.url, `/api/types/${typeslug}/${content.id}`, 'URL points to full content item');
   }
 
-  t.true(attr.hasOwnProperty('meta'), 'Contains Meta');
-  t.false(attr.hasOwnProperty('attributes'), 'Does not contain attributes');
-  t.is(attr.meta.url, `/api/types/${typeslug}/${attr.id}`, 'URL points to full content item');
-
-  return true;
+  // return true;
 };
 
 /**
- * Checks attributes are formatted depending on depth
+ * Checks attributes with references are formatted correctly depending on depth
+ *
  * @param  {object} t - ava testing
  * @param  {object} attrs object containing attributes to test
- * @param  {number} depth - depth function should recurse
+ * @param {object} query - request query
  *
  */
-const depths = (t, attrs, depth) => {
-  let dep = depth;
-  dep--;
+const depths = (t, attrs, query) => {
+  const qry = cloneDeep(query);
+
+  if (qry.hasOwnProperty('depth')) {
+    qry.depth--;
+  }
+  else {
+    qry.depth = 0;
+  }
+
+  if (qry.depth <= 0) {
+    qry.follow = false;
+  }
 
   Object.keys(attrs).forEach(attr => {
+    // we're only checking attributes with references
     if (attr.split('-').indexOf('referencer') > -1) {
-      if (attrs[attr].hasOwnProperty('id')) {
-        formatted(t, attrs[attr]);
-        if (dep > 0) {
-          depths(t, attrs[attr], dep);
-        }
-      }
-      else if (!Array.isArray(attrs[attr])) {
-        Object.keys(attrs[attr]).forEach(atr => {
-          formatted(t, attrs[attr][atr]);
+      // array means it's a repeatable
+      if (Array.isArray(attrs[attr])) {
+        // gets each entry
+        attrs[attr].forEach(entry => {
+          // gets the id of each input
+          Object.keys(entry).forEach(id => {
+            // check formatting
+            formatted(t, entry[id], qry);
+
+            return;
+          });
+
+          return;
         });
       }
+      else {
+        // no id makes this a multi-input
+        if (!attrs[attr].hasOwnProperty('id')) {
+          // gets the id of each input
+          Object.keys(attrs[attr]).forEach(id => {
+            // check formatting
+            formatted(t, attrs[attr][id], qry);
+
+            return;
+          });
+        }
+        else {
+          // check formatting
+          formatted(t, attrs[attr], qry);
+        }
+      }
     }
+
+    return;
   });
 };
 
@@ -393,7 +346,6 @@ const testables = (source, models) => {
 module.exports = {
   type,
   values,
-  referencer,
   formatted,
   depths,
   testables,

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -220,9 +220,7 @@ const referencer = (t, attrs) => {
 
   // an individual piece of content, so we need to test just the attributes
   if (attrs.hasOwnProperty('attributes')) {
-    referencer(t, attrs.attributes);
-
-    return;
+    return referencer(t, attrs.attributes);
   }
 
   // an array of attributes, this set of attributes is a repeatable
@@ -232,9 +230,7 @@ const referencer = (t, attrs) => {
         // an individual piece of content, so we need to test just the attributes
         // at this point, we've found a piece of content _inside_ a piece of content's attributes
         if (attr[atr].hasOwnProperty('attributes')) {
-          referencer(t, attr[atr].attributes);
-
-          return;
+          return referencer(t, attr[atr].attributes);
         }
 
         // we've reached our depth, test `meta` exists
@@ -255,16 +251,12 @@ const referencer = (t, attrs) => {
 
       // if attributes exists, we're still digging down in our depth, recurse!
       if (item.hasOwnProperty('attributes')) {
-        referencer(t, item.attributes);
-
-        return;
+        return referencer(t, item.attributes);
       }
 
       // if it's an array, we're in a repeatable - recurseit!
       if (Array.isArray(item)) {
-        referencer(t, item);
-
-        return;
+        return referencer(t, item);
       }
 
       // non-repeatable attribute with multiple inputs
@@ -296,6 +288,11 @@ const referencer = (t, attrs) => {
   });
 };
 
+/**
+ * Tests for a formatted attribute
+ * @param  {object} t - ava testing
+ * @param  {object} attr object containing attributes to test
+ */
 const formatted = (t, attr) => {
   let typeslug;
 
@@ -324,8 +321,6 @@ const formatted = (t, attr) => {
     t.false(attr.hasOwnProperty('attributes'), 'Does not contain attributes');
     t.is(attr.meta.url, `/api/types/${typeslug}/${attr.id}`, 'URL points to full content item');
   }
-
-
 }
 
 module.exports = {

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -296,8 +296,41 @@ const referencer = (t, attrs) => {
   });
 };
 
+const attribute = (t, attr) => {
+  let typeslug;
+
+  t.true(attr.hasOwnProperty('id'), 'Contains ID');
+  t.true(attr.hasOwnProperty('type'), 'Contains Type');
+
+  if (typeof attr.type === 'object') {
+    t.true(attr.type.hasOwnProperty('name'), 'Contains Type Name');
+    t.true(attr.type.hasOwnProperty('slug'), 'Contains Type Slug');
+    t.true(attr.type.hasOwnProperty('url'), 'Contains Type url');
+    typeslug = attr.type.slug;
+  }
+  else {
+    t.true(attr.hasOwnProperty('type_slug'), 'Contains Type Slug');
+    typeslug = attr.type_slug;
+  }
+
+  t.true(attr.hasOwnProperty('key'), 'Contains Key');
+  t.true(attr.hasOwnProperty('key_slug'), 'Contains Key Slug');
+
+  if (!attr.hasOwnProperty('meta')) {
+    t.true(attr.hasOwnProperty('attributes'), 'Contains attributes');
+  }
+  else {
+    t.true(attr.hasOwnProperty('meta'), 'Contains Meta');
+    t.false(attr.hasOwnProperty('attributes'), 'Does not contain attributes');
+    t.is(attr.meta.url, `/api/types/${typeslug}/${attr.id}`, 'URL points to full content item');
+  }
+
+
+}
+
 module.exports = {
   type,
   values,
   referencer,
+  attribute,
 };

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -296,7 +296,7 @@ const referencer = (t, attrs) => {
   });
 };
 
-const attribute = (t, attr) => {
+const formatted = (t, attr) => {
   let typeslug;
 
   t.true(attr.hasOwnProperty('id'), 'Contains ID');
@@ -332,5 +332,5 @@ module.exports = {
   type,
   values,
   referencer,
-  attribute,
+  formatted,
 };

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -212,6 +212,8 @@ const values = ctype => {
  * Tests attributes with references
  * @param  {object} t - ava testing
  * @param  {object|array} attrs object containing attributes to test
+ *
+ * @returns {object|function|boolean} various returns
  */
 const referencer = (t, attrs) => {
   if (typeof attrs !== 'object' || attrs === undefined) {
@@ -220,7 +222,8 @@ const referencer = (t, attrs) => {
 
   // an individual piece of content, so we need to test just the attributes
   if (attrs.hasOwnProperty('attributes')) {
-    referencer(t, attrs.attributes);
+    // eslint will not allow a return here
+    return referencer(t, attrs.attributes); // eslint-disable-line consistent-return
   }
 
   // an array of attributes, this set of attributes is a repeatable

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -1,217 +1,214 @@
-'use strict'; // eslint-disable-line strict
-
-/*
- * Utility Files for Tests
- */
-
-const ipsum = require('lorem-ipsum');
 const uuid = require('uuid');
+const ipsum = require('lorem-ipsum');
 const slugify = require('underscore.string/slugify');
-const moment = require('moment');
 
-const utils = require('../../lib/utils');
-
-/**
- * Content type model after merged with input plugins via content-types module
- * @typedef {Object} type
- * @property {string} name - name of content type
- * @property {string} id - id of content type
- * @property {string} description - description of content type
- * @property {array} attributes - input attributes
- */
-
-/**
- * array of content types
- * @typedef {array} allTypes
- */
-
-/**
- * Object which tracks the number of pieces of content for each content type
- * @typedef {array} eachOfType
- */
-
-/*
- * Randomly generate content
- */
-const generate = (total, lang) => {
-  const content = [];
-  const lives = [];
-  const types = [];
-  const eachOfType = {};
-  const allTypes = [];
-  const t = total || 50;
-  const language = lang || 'en-us';
-  let i;
-
-
-  /**
-   * Populate an array {allTypes} of content types {type}
-   */
-  for (i = 0; i < 5; i++) {
-    types.push(`Test Type ${ipsum({
-      count: 1,
-      units: 'words',
-    })}`);
-
-    eachOfType[types[i]] = 0;
-    allTypes.push({
-      name: types[i],
-      id: slugify(types[i]),
-      description: ipsum({
-        count: Math.round(Math.random() * 6 + 1),
-        units: 'words',
-      }),
-      attributes: [
-        {
-          name: 'Name',
-          inputs: {
-            text: {
-              label: 'Name',
-              type: 'text',
-              id: uuid.v4(),
-              name: 'name--text',
-            },
-          },
-          id: `${slugify(types[i])}-name`,
-          type: 'text',
-        },
-        {
-          name: 'Textblock',
-          inputs: {
-            textblock: {
-              label: 'Text',
-              type: 'textarea',
-              id: uuid.v4(),
-              name: 'textblock--textarea',
-            },
-          },
-          id: `${slugify(types[i])}-textblock`,
-          type: 'textarea',
-        },
-        {
-          name: 'Referencer',
-          inputs: {
-            referencer: {
-              label: 'Text',
-              type: 'reference',
-              id: uuid.v4(),
-              name: 'referencer--reference',
-            },
-          },
-          id: `${slugify(types[i])}-referencer`,
-          type: 'reference',
-        },
-      ],
-    });
-  }
-
-  /**
-   * Add {type} fixtures to the content array
-   */
-  for (i = 0; i < t; i++) {
-    let referenced = '';
-    const name = ipsum({
-      count: 3,
-      units: 'words',
-      format: 'plain',
-    });
-
-    const id = uuid.v4();
-    const date = moment().format('YYYY-MM-DD');
-
-    const sunrise = moment().format('hh:mm');
-    const sunset = moment().format('hh:mm');
-
-    const type = types[Math.round(Math.random() * 4)];
-
-    eachOfType[type] += 1;
-
-    if (content.length > 0) {
-      // make the last entry the referencee
-      referenced = content[content.length - 1].id;
-    }
-
-    const values = {};
-    values[`${slugify(type)}-name`] = {
-      text: {
-        value: ipsum({
-          count: 1,
-          units: 'words',
-          format: 'plain',
-        }),
-      },
-    };
-    values[`${slugify(type)}-textblock`] = {
-      textblock: {
-        value: ipsum({
-          count: 2,
-          units: 'paragraphs',
-          format: 'plain',
-          sentenceUpperBound: 5,
-          paragraphUpperBound: 3,
-        }),
-      },
-    };
-    values[`${slugify(type)}-referencer`] = {
-      referencer: {
-        value: referenced,
-      },
-    };
-
-    const item = {
-      id,
-      language,
-      'revision': Math.round(Math.random() * 40),
-      'sunrise': utils.time.iso(date, sunrise, 'America/New_York'),
-      'sunrise-timezone': 'America/New_York',
-      'sunset': Date.now() % 6 === 0 ? utils.time.iso(date, sunset, 'America/New_York') : null,
-      'sunset-timezone': 'America/New_York',
-      'identifier': name,
-      'slug': slugify(name),
-      type,
-      'type-slug': slugify(type),
-      'value': values,
-    };
-
-    content[i] = item;
-
-    const live = {
-      id,
-      language,
-      'sunrise': utils.time.iso(date, sunrise, 'America/New_York'),
-      'sunset': Date.now() % 6 === 0 ? utils.time.iso(date, sunset, 'America/New_York') : null,
-      'attributes': values,
-      'key': name,
-      'key-slug': slugify(name),
-      type,
-      'type-slug': slugify(type),
-      'revision': Math.round(Math.random() * 40),
-    };
-
-    lives[i] = live;
-  }
-
+const type = name => {
   return {
-    content,
-    live: lives,
-    types: {
-      names: types,
-      each: eachOfType,
-      full: allTypes,
-    },
+    name,
+    id: slugify(name),
+    description: ipsum({
+      count: Math.round(Math.random() * 6 + 1),
+      units: 'words',
+    }),
+    attributes: [
+      {
+        name: 'Name',
+        inputs: {
+          text: {
+            label: 'Name',
+            type: 'text',
+            id: uuid.v4(),
+            name: 'name--text',
+          },
+        },
+        id: `${slugify(name)}-name`,
+        type: 'text',
+      },
+      {
+        name: 'Textblock',
+        inputs: {
+          textblock: {
+            label: 'Text',
+            type: 'textarea',
+            id: uuid.v4(),
+            name: 'textblock--textarea',
+          },
+        },
+        id: `${slugify(name)}-textblock`,
+        type: 'textarea',
+      },
+      {
+        name: 'Referencer',
+        inputs: {
+          referencer: {
+            label: 'Text',
+            type: 'reference',
+            id: uuid.v4(),
+            name: 'referencer--reference',
+            settings: {
+              contentType: 'will-be-changed',
+            },
+            reference: true,
+          },
+        },
+        id: `${slugify(name)}-referencer`,
+        type: 'reference',
+      },
+      {
+        name: 'Referencer Dual',
+        inputs: {
+          referencerdual1: {
+            label: 'Referencer 1',
+            type: 'reference',
+            id: uuid.v4(),
+            name: 'referencer1--reference',
+            settings: {
+              contentType: 'will-be-changed',
+            },
+            reference: true,
+          },
+          referencerdual2: {
+            label: 'Referencer 2',
+            type: 'reference',
+            id: uuid.v4(),
+            name: 'referencer2--reference',
+            settings: {
+              contentType: 'will-be-changed',
+            },
+            reference: true,
+          },
+        },
+        id: `${slugify(name)}-referencer-dual`,
+        type: 'reference',
+      },
+      {
+        name: 'Referencer Repeating',
+        inputs: {
+          referencerrepeat: {
+            label: 'Ref Repeat',
+            type: 'reference',
+            id: uuid.v4(),
+            name: 'referencer-repeating--reference',
+            settings: {
+              contentType: 'will-be-changed',
+            },
+            reference: true,
+          },
+        },
+        id: `${slugify(name)}-referencer-repeating`,
+        type: 'reference',
+        repeatable: true,
+      },
+      {
+        name: 'Referencer Dual Repeating',
+        inputs: {
+          referencerdualrepeat1: {
+            label: 'Referencer 1',
+            type: 'reference',
+            id: uuid.v4(),
+            name: 'referencer1--reference-repeating',
+            settings: {
+              contentType: 'will-be-changed',
+            },
+            reference: true,
+          },
+          referencerdualrepeat2: {
+            label: 'Referencer 2',
+            type: 'reference',
+            id: uuid.v4(),
+            name: 'referencer2--reference-repeating',
+            settings: {
+              contentType: 'will-be-changed',
+            },
+            reference: true,
+          },
+        },
+        id: `${slugify(name)}-referencer-dual-repeating`,
+        type: 'reference',
+        repeatable: true,
+      },
+    ],
   };
 };
 
-/*
- * Basic validation function
- *
- * @returns true
- */
-const validation = function validation() {
-  return true;
+const values = ctype => {
+  const results = {};
+  results[`${slugify(ctype)}-name`] = {
+    text: {
+      value: ipsum({
+        count: 1,
+        units: 'words',
+        format: 'plain',
+      }),
+    },
+  };
+  results[`${slugify(ctype)}-textblock`] = {
+    textblock: {
+      value: ipsum({
+        count: 2,
+        units: 'paragraphs',
+        format: 'plain',
+        sentenceUpperBound: 5,
+        paragraphUpperBound: 3,
+      }),
+    },
+  };
+  results[`${slugify(ctype)}-referencer`] = {
+    referencer: {
+      value: 'make-me-an-id',
+    },
+  };
+  results[`${slugify(ctype)}-referencer-dual`] = {
+    referencerdual1: {
+      value: 'make-me-an-id',
+    },
+    referencerdual2: {
+      value: 'make-me-an-id',
+    },
+  };
+  results[`${slugify(ctype)}-referencer-repeating`] = [
+    {
+      referencerrepeat: {
+        value: 'make-me-an-id',
+      },
+    },
+    {
+      referencerrepeat: {
+        value: 'make-me-an-id',
+      },
+    },
+  ];
+  results[`${slugify(ctype)}-referencer-dual-repeating`] = [
+    {
+      referencerdualrepeat1: {
+        value: 'make-me-an-id',
+      },
+      referencerdualrepeat2: {
+        value: 'make-me-an-id',
+      },
+    },
+    {
+      referencerdualrepeat1: {
+        value: 'make-me-an-id',
+      },
+      referencerdualrepeat2: {
+        value: 'make-me-an-id',
+      },
+    },
+    {
+      referencerdualrepeat1: {
+        value: 'make-me-an-id',
+      },
+      referencerdualrepeat2: {
+        value: 'make-me-an-id',
+      },
+    },
+  ];
+
+  return results;
 };
 
 module.exports = {
-  generate,
-  validation,
+  type,
+  values,
 };

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -301,6 +301,8 @@ const referencer = (t, attrs) => {
  * Tests for a formatted attribute
  * @param  {object} t - ava testing
  * @param  {object} attr object containing attributes to test
+ *
+ * @returns {boolean} returns true
  */
 const formatted = (t, attr) => {
   let typeslug;
@@ -324,24 +326,27 @@ const formatted = (t, attr) => {
 
   if (!attr.hasOwnProperty('meta')) {
     t.true(attr.hasOwnProperty('attributes'), 'Contains attributes');
+
     return referencer(t, attr.attributes);
   }
-  else {
-    t.true(attr.hasOwnProperty('meta'), 'Contains Meta');
-    t.false(attr.hasOwnProperty('attributes'), 'Does not contain attributes');
-    t.is(attr.meta.url, `/api/types/${typeslug}/${attr.id}`, 'URL points to full content item');
-  }
+
+  t.true(attr.hasOwnProperty('meta'), 'Contains Meta');
+  t.false(attr.hasOwnProperty('attributes'), 'Does not contain attributes');
+  t.is(attr.meta.url, `/api/types/${typeslug}/${attr.id}`, 'URL points to full content item');
+
+  return true;
 };
 
 /**
  * Checks attributes are formatted depending on depth
- * @param  {[type]} t     [description]
- * @param  {[type]} attrs [description]
+ * @param  {object} t - ava testing
+ * @param  {object} attrs object containing attributes to test
+ * @param  {number} depth - depth function should recurse
  *
- * @returns {[type]}       [description]
  */
 const depths = (t, attrs, depth) => {
-  let dep = depth--;
+  let dep = depth;
+  dep--;
 
   Object.keys(attrs).forEach(attr => {
     if (attr.split('-').indexOf('referencer') > -1) {

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -236,6 +236,7 @@ const referencer = (t, attrs) => {
         // we've reached our depth, test `meta` exists
         else if (attr[atr].hasOwnProperty('id')) {
           t.true(attr[atr].hasOwnProperty('meta'), 'attribute in array contains meta');
+          t.true(attr[atr].meta.hasOwnProperty('url'), 'attribute in array contains meta url');
 
           return;
         }
@@ -273,6 +274,7 @@ const referencer = (t, attrs) => {
         // no attributes - it should have a meta then
         Object.keys(item).forEach(itm => {
           t.true(item[itm].hasOwnProperty('meta'), 'attribute in array contains meta');
+          t.true(item[itm].meta.hasOwnProperty('url'), 'attribute in array contains meta url');
 
           return;
         });
@@ -281,6 +283,7 @@ const referencer = (t, attrs) => {
       // non-repeatable; single input
       else {
         t.true(item.hasOwnProperty('meta'), 'attribute in array contains meta');
+        t.true(item.meta.hasOwnProperty('url'), 'attribute in array contains meta url');
 
         return;
       }

--- a/tests/fixtures/_utils.js
+++ b/tests/fixtures/_utils.js
@@ -220,7 +220,7 @@ const referencer = (t, attrs) => {
 
   // an individual piece of content, so we need to test just the attributes
   if (attrs.hasOwnProperty('attributes')) {
-    return referencer(t, attrs.attributes);
+    referencer(t, attrs.attributes);
   }
 
   // an array of attributes, this set of attributes is a repeatable
@@ -238,8 +238,10 @@ const referencer = (t, attrs) => {
           t.true(attr[atr].hasOwnProperty('meta'), 'attribute in array contains meta');
           t.true(attr[atr].meta.hasOwnProperty('url'), 'attribute in array contains meta url');
 
-          return;
+          return true;
         }
+
+        return true;
       });
     });
   }
@@ -250,7 +252,7 @@ const referencer = (t, attrs) => {
     if (attr.split('-').indexOf('referencer') > -1) {
       const item = attrs[attr];
 
-      // if attributes exists, we're still digging down in our depth, recurse!
+      // if attributes exists, we're still digging down in our depth, recurseit!
       if (item.hasOwnProperty('attributes')) {
         return referencer(t, item.attributes);
       }
@@ -265,10 +267,10 @@ const referencer = (t, attrs) => {
         // if it has attributes, we're not at depth so....uuuuuuhhhhhhhaaaAAAAHHHH recursit!
         if (item[Object.keys(item)[0]].hasOwnProperty('attributes')) {
           Object.keys(item).forEach(itm => {
-            referencer(t, item[itm].attributes);
+            return referencer(t, item[itm].attributes);
           });
 
-          return;
+          return true;
         }
 
         // no attributes - it should have a meta then
@@ -276,7 +278,7 @@ const referencer = (t, attrs) => {
           t.true(item[itm].hasOwnProperty('meta'), 'attribute in array contains meta');
           t.true(item[itm].meta.hasOwnProperty('url'), 'attribute in array contains meta url');
 
-          return;
+          return true;
         });
       }
 
@@ -284,10 +286,10 @@ const referencer = (t, attrs) => {
       else {
         t.true(item.hasOwnProperty('meta'), 'attribute in array contains meta');
         t.true(item.meta.hasOwnProperty('url'), 'attribute in array contains meta url');
-
-        return;
       }
     }
+
+    return true;
   });
 };
 
@@ -324,7 +326,7 @@ const formatted = (t, attr) => {
     t.false(attr.hasOwnProperty('attributes'), 'Does not contain attributes');
     t.is(attr.meta.url, `/api/types/${typeslug}/${attr.id}`, 'URL points to full content item');
   }
-}
+};
 
 module.exports = {
   type,

--- a/tests/fixtures/applications/objects/model-merged.js
+++ b/tests/fixtures/applications/objects/model-merged.js
@@ -1,4 +1,4 @@
-const validation = require('../../_utils').validation;
+const validation = require('../../').validation;
 
 /**
  * Mock of `applications` merged-content-type object

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -1,0 +1,221 @@
+'use strict'; // eslint-disable-line strict
+
+/*
+ * Utility Files for Tests
+ */
+
+const ipsum = require('lorem-ipsum');
+const uuid = require('uuid');
+const slugify = require('underscore.string/slugify');
+const moment = require('moment');
+const _ = require('lodash');
+
+const futils = require('./_utils');
+
+const utils = require('../../lib/utils');
+
+/**
+ * Content type model after merged with input plugins via content-types module
+ * @typedef {Object} type
+ * @property {string} name - name of content type
+ * @property {string} id - id of content type
+ * @property {string} description - description of content type
+ * @property {array} attributes - input attributes
+ */
+
+/**
+ * array of content types
+ * @typedef {array} allTypes
+ */
+
+/**
+ * Object which tracks the number of pieces of content for each content type
+ * @typedef {array} eachOfType
+ */
+
+/*
+ * Randomly generate content
+ */
+const generate = (total, lang) => {
+  let content = [];
+  const lives = [];
+  const types = [];
+  const refs = {
+    types: {},
+    content: {},
+  };
+  const eachOfType = {};
+  let allTypes = [];
+  const t = total || 50;
+  const language = lang || 'en-us';
+  let i;
+
+
+  /**
+   * Populate an array {allTypes} of content types {type}
+   */
+  for (i = 0; i < 5; i++) {
+    types.push(`Test Type ${ipsum({
+      count: 1,
+      units: 'words',
+    })}`);
+
+    eachOfType[types[i]] = 0;
+    refs.content[slugify(types[i])] = [];
+
+    allTypes.push(futils.type(types[i]));
+  }
+
+  /**
+   * Cycle through All Types and give a content-type ID to all references
+   */
+  allTypes = allTypes.map(tp => {
+    const type = tp;
+    const others = _.cloneDeep(types).filter(typ => {
+      return typ !== type;
+    });
+    const random = Math.round(Math.random() * Math.round(others.length - 1));
+
+    // go through each attribute and assign a content type for references
+    type.attributes = type.attributes.map(atr => {
+      const attr = atr;
+      Object.keys(attr.inputs).forEach(inp => {
+        const input = attr.inputs[inp];
+        if (input.hasOwnProperty('reference') && input.hasOwnProperty('settings')) {
+          input.settings.contentType = slugify(others[random]);
+        }
+
+        attr.inputs[inp] = input;
+      });
+
+      return attr;
+    });
+
+    // store contentType used by all this type's attributes
+    refs.types[type.id] = slugify(others[random]);
+
+    return type;
+  });
+
+  // get the number of content types
+  let typesnum = types.length - 1;
+
+  /**
+   * Add {type} fixtures to the content array
+   */
+  for (i = 0; i < t; i++) {
+    const name = ipsum({
+      count: 3,
+      units: 'words',
+      format: 'plain',
+    });
+
+    const id = uuid.v4();
+    const date = moment().format('YYYY-MM-DD');
+
+    const sunrise = moment().format('hh:mm');
+    const sunset = moment().format('hh:mm');
+
+    if (typesnum < 0) {
+      typesnum = types.length - 1;
+    }
+
+    // goes through each type (instead of random) to make sure no types are empty
+    const type = types[typesnum];
+    typesnum--;
+
+    // store id under this content type
+    refs.content[slugify(type)].push(id);
+
+    // track number of pieces of content for each type
+    eachOfType[type] += 1;
+
+    const values = futils.values(type);
+
+    const item = {
+      id,
+      language,
+      'revision': Math.round(Math.random() * 40),
+      'sunrise': utils.time.iso(date, sunrise, 'America/New_York'),
+      'sunrise-timezone': 'America/New_York',
+      'sunset': Date.now() % 6 === 0 ? utils.time.iso(date, sunset, 'America/New_York') : null,
+      'sunset-timezone': 'America/New_York',
+      'identifier': name,
+      'slug': slugify(name),
+      type,
+      'type-slug': slugify(type),
+      'value': values,
+    };
+
+    content[i] = item;
+
+    const live = {
+      id,
+      language,
+      'sunrise': utils.time.iso(date, sunrise, 'America/New_York'),
+      'sunset': Date.now() % 6 === 0 ? utils.time.iso(date, sunset, 'America/New_York') : null,
+      'attributes': values,
+      'key': name,
+      'key-slug': slugify(name),
+      type,
+      'type-slug': slugify(type),
+      'revision': Math.round(Math.random() * 40),
+    };
+
+    lives[i] = live;
+  }
+
+  // add referenced UUIDs to content/live
+  content = content.map(ct => {
+    let cont = ct;
+    const live = lives.findIndex(elm => {
+      return elm.id === cont.id;
+    });
+
+    // get the source of referenced content
+    const source = {
+      type: refs.types[slugify(ct.type)],
+      ids: refs.content[refs.types[slugify(ct.type)]],
+    };
+
+    // need a random number to get id
+    const random = Math.round(Math.random() * Math.round(source.ids.length - 1));
+
+    // replace every id placeholder wiht a random id from the correct content-type
+    const replaced = JSON.stringify(cont, null, 2).replace(/make-me-an-id/g, source.ids[random]);
+    cont = JSON.parse(replaced);
+
+    // replace live data too
+    lives[live].attributes = cont.value;
+
+    return cont;
+  });
+
+// console.log(JSON.stringify(content, null, 2));
+// console.log(JSON.stringify(lives, null, 2));
+
+  return {
+    content,
+    live: lives,
+    references: utils.references(allTypes).references,
+    types: {
+      names: types,
+      each: eachOfType,
+      full: allTypes,
+    },
+  };
+};
+
+/*
+ * Basic validation function
+ *
+ * @returns true
+ */
+const validation = function validation() {
+  return true;
+};
+
+module.exports = {
+  generate,
+  validation,
+};

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -55,10 +55,7 @@ const generate = (total, lang) => {
    * Populate an array {allTypes} of content types {type}
    */
   for (i = 0; i < 5; i++) {
-    types.push(`Test Type ${ipsum({
-      count: 1,
-      units: 'words',
-    })}`);
+    types.push(`Test Type Foo${i}`);
 
     eachOfType[types[i]] = 0;
     refs.content[slugify(types[i])] = [];
@@ -220,4 +217,6 @@ module.exports = {
   validation,
   formatted: futils.formatted,
   referencer: futils.referencer,
+  depths: futils.depths,
+  testables: futils.testables,
 };

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -218,4 +218,5 @@ const validation = function validation() {
 module.exports = {
   generate,
   validation,
+  referencer: futils.referencer,
 };

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -218,5 +218,6 @@ const validation = function validation() {
 module.exports = {
   generate,
   validation,
+  attribute: futils.attribute,
   referencer: futils.referencer,
 };

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -218,6 +218,6 @@ const validation = function validation() {
 module.exports = {
   generate,
   validation,
-  attribute: futils.attribute,
+  formatted: futils.formatted,
   referencer: futils.referencer,
 };

--- a/tests/generate-fixtures.js
+++ b/tests/generate-fixtures.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import slugify from 'underscore.string/slugify';
 import isUUID from 'validator/lib/isUUID';
 
-import utils from './fixtures/_utils';
+import utils from './fixtures';
 
 const generated = 17;
 
@@ -15,6 +15,7 @@ test('Fixtures generated', t => {
   t.true(Array.isArray(fixtures.types.names), '`types.names` exists and is an array');
   t.true(Array.isArray(fixtures.types.full), '`types.full` exists and is an array');
   t.true(Array.isArray(fixtures.content), '`content` exists and is an array');
+  t.true(Array.isArray(fixtures.references), '`references` exists and is an array');
 });
 
 //////////////////////////////
@@ -96,9 +97,21 @@ test('Test Utility - fixtures - content', t => {
     t.true(item.hasOwnProperty('value'), 'Contains value');
     t.is(typeof item.value, 'object', 'Value is an object');
     Object.keys(item.value).forEach(val => {
-      Object.keys(item.value[val]).forEach(input => {
-        t.true(item.value[val][input].hasOwnProperty('value'), 'Value input contains a value');
-      });
+      if (Array.isArray(item.value[val])) {
+        // check repeaters
+        item.value[val].forEach(rep => {
+          Object.keys(rep).forEach(input => {
+            t.true(rep[input].hasOwnProperty('value'), 'Value input contains a value');
+            t.not(rep[input].value, null, 'value is not null');
+          });
+        });
+      }
+      else {
+        Object.keys(item.value[val]).forEach(input => {
+          t.true(item.value[val][input].hasOwnProperty('value'), 'Value input contains a value');
+          t.not(item.value[val][input].value, null, 'value is not null');
+        });
+      }
     });
   });
 });
@@ -127,11 +140,41 @@ test('Test Utility - fixtures - live', t => {
     t.true(item.hasOwnProperty('type-slug'), 'Contains type-slug');
     t.is(slugify(item.type), item['type-slug'], 'type-slug is slugify-ed type');
     t.true(item.hasOwnProperty('attributes'), 'Contains value');
-    t.is(typeof item.attributes, 'object', 'Value is an object');
-    Object.keys(item.attributes).forEach(attr => {
-      Object.keys(item.attributes[attr]).forEach(input => {
-        t.true(item.attributes[attr][input].hasOwnProperty('value'), 'Value input contains a value');
-      });
+    t.is(typeof item.attributes, 'object', 'attributes is an object');
+    Object.keys(item.attributes).forEach(val => {
+      if (Array.isArray(item.attributes[val])) {
+        // check repeaters
+        item.attributes[val].forEach(rep => {
+          Object.keys(rep).forEach(input => {
+            t.true(rep[input].hasOwnProperty('value'), 'attributes input contains a value');
+            t.not(rep[input].value, null, 'value is not null');
+          });
+        });
+      }
+      else {
+        Object.keys(item.attributes[val]).forEach(input => {
+          t.true(item.attributes[val][input].hasOwnProperty('value'), 'attributes input contains a value');
+          t.not(item.attributes[val][input].value, null, 'value is not null');
+        });
+      }
     });
+  });
+});
+
+//////////////////////////////
+// Fixtures - references
+//////////////////////////////
+test('Test Utility - fixtures - references', t => {
+  const references = fixtures.references;
+
+  t.pass();
+
+  t.is(references.length, 30, 'should have 30 possible references');
+
+  references.forEach(item => {
+    t.true(item.hasOwnProperty('type'), 'Contains type');
+    t.true(item.hasOwnProperty('attr'), 'Contains attr');
+    t.true(item.hasOwnProperty('input'), 'Contains input');
+    t.true(item.hasOwnProperty('ct'), 'Contains ct');
   });
 });

--- a/tests/schedule.js
+++ b/tests/schedule.js
@@ -4,7 +4,7 @@ import Promise from 'bluebird';
 
 import sutils from '../lib/schedule/utils';
 import putils from '../lib/utils';
-import utils from './fixtures/_utils';
+import utils from './fixtures';
 import database from '../lib/database';
 import apps from './fixtures/applications/objects/database-mocks.js';
 

--- a/tests/schedule.js
+++ b/tests/schedule.js
@@ -8,36 +8,30 @@ import utils from './fixtures';
 import database from '../lib/database';
 import apps from './fixtures/applications/objects/database-mocks.js';
 
-const fixtures = utils.generate();
+const lang = 'schedule-test';
+const generated = 23;
+
+const fixtures = utils.generate(generated, lang);
+
 const length = fixtures.content.length;
 const count = Math.floor(Math.random() * length);
-const types = fixtures.types.names;
 
 test.cb.before(t => {
   database.init().then(() => {
-    t.end();
-  }).catch(e => {
-    t.fail(e);
-  });
-});
-
-test.cb.after.always(t => {
-  const items = types.map(type => {
-    return database('live').where('type', type).del().then(() => {
-      return database('schedule').where('type', type).del();
-    });
-  });
-
-  Promise.all(items)
-    .then(() => {
+    database('live').where('language', lang).del().then(() => {
       t.end();
-    })
-    .catch(e => {
-      t.fail(e);
+    }).catch(e => { // because we can't return in a before, this catch doesn't bubble out
+      console.error(e.stack); // eslint-disable-line no-console
+      t.fail(e.stack);
     });
+  })
+  .catch(e => {
+    console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e.stack);
+  });
 });
 
-test('Setup', t => {
+test.skip('Setup', t => {
   const item = count;
   const revision = fixtures.content[item];
 
@@ -91,7 +85,7 @@ test('Pull', t => {
   return database('live').insert({
     'id': revision.id,
     'revision': revision.revision,
-    'language': revision.language,
+    'language': lang,
     'sunrise': revision.sunrise,
     'sunset': revision.sunset,
     'attributes': revision.value,
@@ -149,7 +143,7 @@ test.skip('Sunset', t => {
   return database('live').insert({
     'id': revision.id,
     'revision': revision.revision,
-    'language': revision.language,
+    'language': lang,
     'sunrise': revision.sunrise,
     'sunset': revision.sunset,
     'attributes': revision.value,
@@ -171,5 +165,20 @@ test.skip('Sunset', t => {
   }).catch(e => {
     console.error(e.message); // eslint-disable-line no-console
     t.fail(e.message);
+  });
+});
+
+
+//////////////////////////////
+// AFTER ALL TESTS RUN
+//////////////////////////////
+test.cb.after.always(t => {
+  database('live').where('language', lang).del().then(() => {
+    t.end();
+  })
+  .catch(e => {
+    console.error(e.stack); // eslint-disable-line no-console
+    t.fail(e);
+    t.end();
   });
 });


### PR DESCRIPTION
Tests and generated content updated for the changes to api to add depth for references.

_note:_ tests are run `serial` in the api tests to avoid a knex timeout issue due to the `follow` function not using knex's `transaction` setup.

---
Relates to #408

`DCO 1.1 Signed-off-by: Scott Nath <github@scottnath.com>`

