### PR TITLE
Fix Yarn install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ services:
 #########################
 before_install:
   # Repo for Yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq yarn


### PR DESCRIPTION
Fixes Yarn install on Travis

Travis was failing with previous fetch keys, updates to latest recommendation from https://yarnpkg.com/en/docs/install-ci#travis-tab

---
Related to breaking build in https://github.com/punchcard-cms/punchcard/pull/521

`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`