### PR TITLE
Required text label bug fix - CSS

### DIFF
--- a/src/sass/partials/components/_forms.scss
+++ b/src/sass/partials/components/_forms.scss
@@ -183,10 +183,12 @@
   &--save {
     background-color: setting-get('primary support color');
     font-weight: setting-get('normal font weight');
+    margin-left: setting-get('rhythm') / 2;
   }
 
   &--publish {
     background-color: setting-get('secondary support color');
     font-weight: setting-get('normal font weight');
+    margin-left: setting-get('rhythm') / 2;
   }
 }


### PR DESCRIPTION
CSS change for issue #530 to fix the spacing issue between the label and the required text mark.

---
Resolves #530

`DCO 1.1 Signed-off-by: NICK TILDEN <NICK@INEEDSUBSTANCE.COM>`

